### PR TITLE
Feat/oracle

### DIFF
--- a/Masa.Framework.sln
+++ b/Masa.Framework.sln
@@ -569,11 +569,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Contrib.Authentication
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Authentication", "Authentication", "{FC4A0C94-47F7-4C9A-A7EC-138DE8EB842D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Masa.Contrib.Service.Caller.Authentication.OpenIdConnect", "src\Contrib\Service\Caller\Authentication\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.csproj", "{9BB5CC86-C2E8-4859-9610-50DB263605A3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Contrib.Service.Caller.Authentication.OpenIdConnect", "src\Contrib\Service\Caller\Authentication\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.csproj", "{9BB5CC86-C2E8-4859-9610-50DB263605A3}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8D7D3D21-86DB-4FCC-8FF0-6E1587ABD22A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.Tests", "src\Contrib\Service\Caller\Authentication\Tests\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.Tests\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.Tests.csproj", "{BEA8E5A5-E7BD-4165-80CD-D1F53ED82D02}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.Tests", "src\Contrib\Service\Caller\Authentication\Tests\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.Tests\Masa.Contrib.Service.Caller.Authentication.OpenIdConnect.Tests.csproj", "{BEA8E5A5-E7BD-4165-80CD-D1F53ED82D02}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle", "src\Contrib\Authentication\OpenIdConnect\Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle\Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.csproj", "{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2039,6 +2041,14 @@ Global
 		{BEA8E5A5-E7BD-4165-80CD-D1F53ED82D02}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BEA8E5A5-E7BD-4165-80CD-D1F53ED82D02}.Release|x64.ActiveCfg = Release|Any CPU
 		{BEA8E5A5-E7BD-4165-80CD-D1F53ED82D02}.Release|x64.Build.0 = Release|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Debug|x64.Build.0 = Debug|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Release|x64.ActiveCfg = Release|Any CPU
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2322,6 +2332,7 @@ Global
 		{9BB5CC86-C2E8-4859-9610-50DB263605A3} = {FC4A0C94-47F7-4C9A-A7EC-138DE8EB842D}
 		{8D7D3D21-86DB-4FCC-8FF0-6E1587ABD22A} = {FC4A0C94-47F7-4C9A-A7EC-138DE8EB842D}
 		{BEA8E5A5-E7BD-4165-80CD-D1F53ED82D02} = {8D7D3D21-86DB-4FCC-8FF0-6E1587ABD22A}
+		{03F476EF-022A-4370-B1C3-FEEDE3BB4E7F} = {41769FBF-91A8-48D1-B3BB-CAE4C814E7CD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {40383055-CC50-4600-AD9A-53C14F620D03}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceClaimEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceClaimEntityTypeConfiguration.cs
@@ -1,0 +1,16 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiResourceClaimEntityTypeConfiguration : IEntityTypeConfiguration<ApiResourceClaim>
+{
+    public void Configure(EntityTypeBuilder<ApiResourceClaim> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.HasOne(x => x.UserClaim).WithMany().HasForeignKey(x => x.UserClaimId)
+            .HasConstraintName("FK_ApiResClaim_UserClaimId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasIndex(x => x.ApiResourceId).HasDatabaseName("IX_ApiResClaim_ApiResourceId");
+        builder.HasIndex(x => x.UserClaimId).HasDatabaseName("IX_ApiResClaim_UserClaimId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceEntityTypeConfiguration.cs
@@ -1,0 +1,24 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiResourceEntityTypeConfiguration : IEntityTypeConfiguration<ApiResource>
+{
+    public void Configure(EntityTypeBuilder<ApiResource> builder)
+    {
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.DisplayName).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.Description).HasMaxLength(1000).IsRequired(false);
+        builder.Property(x => x.AllowedAccessTokenSigningAlgorithms).HasMaxLength(100).IsRequired(false).HasColumnName("AllowedTokenSignAlgorithm");
+        builder.HasIndex(x => x.Name).IsUnique().HasFilter("[IsDeleted] = 0").HasDatabaseName("IX_ApiResource_Name");
+        builder.HasMany(x => x.Secrets).WithOne(x => x.ApiResource).HasForeignKey(x => x.ApiResourceId)
+            .HasConstraintName("FK_ApiResSecret_ResourceId").OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.ApiScopes).WithOne(x => x.ApiResource).HasForeignKey(x => x.ApiResourceId)
+            .HasConstraintName("FK_ApiResScope_ResourceId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.UserClaims).WithOne(x => x.ApiResource).HasForeignKey(x => x.ApiResourceId)
+            .HasConstraintName("FK_ApiResClaim_ResourceId").OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.Properties).WithOne(x => x.ApiResource).HasForeignKey(x => x.ApiResourceId)
+            .HasConstraintName("FK_ApiResProp_ResourceId").OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourcePropertyEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourcePropertyEntityTypeConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiResourcePropertyEntityTypeConfiguration : IEntityTypeConfiguration<ApiResourceProperty>
+{
+    public void Configure(EntityTypeBuilder<ApiResourceProperty> builder)
+    {
+        builder.Property(x => x.Key).HasMaxLength(250).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(2000).IsRequired();
+        builder.HasIndex(x => x.ApiResourceId).HasDatabaseName("IX_ApiResProp_ApiResourceId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceScopeEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceScopeEntityTypeConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiResourceScopeEntityTypeConfiguration : IEntityTypeConfiguration<ApiResourceScope>
+{
+    public void Configure(EntityTypeBuilder<ApiResourceScope> builder)
+    {
+        builder.HasKey(apiResourceScope => apiResourceScope.Id);
+        builder.HasOne(x => x.ApiScope).WithMany().HasForeignKey(x => x.ApiScopeId).HasConstraintName("FK_ApiResScope_ScopeId");
+        builder.HasIndex(x => x.ApiResourceId).HasDatabaseName("IX_ApiResScope_ApiScopeId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceSecretEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiResourceSecretEntityTypeConfiguration.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiResourceSecretEntityTypeConfiguration : IEntityTypeConfiguration<ApiResourceSecret>
+{
+    public void Configure(EntityTypeBuilder<ApiResourceSecret> builder)
+    {
+        builder.Property(x => x.Description).HasMaxLength(1000).IsRequired(false);
+        builder.Property(x => x.Value).HasMaxLength(4000).IsRequired();
+        builder.Property(x => x.Type).HasMaxLength(250).IsRequired();
+        builder.HasIndex(x => x.ApiResourceId).HasDatabaseName("IX_ApiResSecret_ApiResourceId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiScopeClaimEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiScopeClaimEntityTypeConfiguration.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiScopeClaimEntityTypeConfiguration : IEntityTypeConfiguration<ApiScopeClaim>
+{
+    public void Configure(EntityTypeBuilder<ApiScopeClaim> builder)
+    {
+        builder.HasKey(apiScopeClaim => apiScopeClaim.Id);
+
+        builder.HasOne(x => x.UserClaim).WithMany().HasForeignKey(x => x.UserClaimId)
+            .HasConstraintName("FK_ApiScopeClaim_UserClaimId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiScopeEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiScopeEntityTypeConfiguration.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiScopeEntityTypeConfiguration : IEntityTypeConfiguration<ApiScope>
+{
+    public void Configure(EntityTypeBuilder<ApiScope> builder)
+    {
+        builder.HasIndex(apiScope => apiScope.Name).IsUnique().HasDatabaseName("IX_ApiScope_Name");
+
+        builder.Property(apiScope => apiScope.Name).HasMaxLength(200).IsRequired();
+        builder.Property(apiScope => apiScope.DisplayName).HasMaxLength(200).IsRequired(false);
+        builder.Property(apiScope => apiScope.Description).HasMaxLength(1000).IsRequired(false);
+
+        builder.HasMany(apiScope => apiScope.UserClaims).WithOne(apiScope => apiScope.ApiScope).HasForeignKey(apiScope => apiScope.ApiScopeId)
+            .HasConstraintName("FK_ApiScopeClaim_ApiScopeId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(x => x.Properties).WithOne(x => x.Scope).HasForeignKey(x => x.ScopeId)
+            .HasConstraintName("FK_ApiScopeProp_ScopeId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiScopePropertyEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ApiScopePropertyEntityTypeConfiguration.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ApiScopePropertyEntityTypeConfiguration : IEntityTypeConfiguration<ApiScopeProperty>
+{
+    public void Configure(EntityTypeBuilder<ApiScopeProperty> builder)
+    {
+        builder.Property(x => x.Key).HasMaxLength(250).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(2000).IsRequired();
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientClaimEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientClaimEntityTypeConfiguration.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientClaimEntityTypeConfiguration : IEntityTypeConfiguration<ClientClaim>
+{
+    public void Configure(EntityTypeBuilder<ClientClaim> builder)
+    {
+        builder.Property(x => x.Type).HasMaxLength(250).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(250).IsRequired();
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientCorsOriginEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientCorsOriginEntityTypeConfiguration.cs
@@ -1,0 +1,12 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientCorsOriginEntityTypeConfiguration : IEntityTypeConfiguration<ClientCorsOrigin>
+{
+    public void Configure(EntityTypeBuilder<ClientCorsOrigin> builder)
+    {
+        builder.Property(x => x.Origin).HasMaxLength(150).IsRequired();
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientEntityTypeConfiguration.cs
@@ -1,0 +1,48 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientEntityTypeConfiguration : IEntityTypeConfiguration<Client>
+{
+    public void Configure(EntityTypeBuilder<Client> builder)
+    {
+        builder.Property(x => x.ClientId).HasMaxLength(400).IsRequired();
+        builder.Property(x => x.ProtocolType).HasMaxLength(400).IsRequired();
+        builder.Property(x => x.ClientName).HasMaxLength(400);
+        builder.Property(x => x.ClientUri).HasMaxLength(2000).IsRequired(false);
+        builder.Property(x => x.LogoUri).HasMaxLength(2000).IsRequired(false);
+        builder.Property(x => x.Description).HasMaxLength(1000).IsRequired(false);
+        builder.Property(x => x.FrontChannelLogoutUri).HasMaxLength(2000).IsRequired(false);
+        builder.Property(x => x.BackChannelLogoutUri).HasMaxLength(2000).IsRequired(false);
+        builder.Property(x => x.ClientClaimsPrefix).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.PairWiseSubjectSalt).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.UserCodeType).HasMaxLength(100).IsRequired(false);
+        builder.Property(x => x.AllowedIdentityTokenSigningAlgorithms).HasMaxLength(100).IsRequired(false).HasColumnName("AllowedIdTokenSignAlgorithm");
+        builder.Property(x => x.FrontChannelLogoutSessionRequired).HasColumnName("FrontChannelLogoutSessionReq");
+        builder.Property(x => x.AlwaysIncludeUserClaimsInIdToken).HasColumnName("AlwaysIncUserClaimsInIdToken");
+        builder.Property(x => x.BackChannelLogoutSessionRequired).HasColumnName("BackChannelLogoutSessionReq");
+        builder.Property(x => x.UpdateAccessTokenClaimsOnRefresh).HasColumnName("UpdateTokenClaimsOnRefresh");
+        //builder.HasIndex(x => x.ClientId);
+        builder.HasIndex(x => x.ClientId).IsUnique().HasFilter("[IsDeleted] = 0").HasDatabaseName("IX_Client_ClientId");
+
+        builder.HasMany(x => x.AllowedGrantTypes).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientGrantType_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.RedirectUris).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientRedirectUri_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.PostLogoutRedirectUris).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientPostLotRUri_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.AllowedScopes).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientScope_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.ClientSecrets).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientSecret_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.Claims).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientClaim_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.IdentityProviderRestrictions).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientIdPRest_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.AllowedCorsOrigins).WithOne(x => x.Client).HasForeignKey(x=> x.ClientId)
+            .HasConstraintName("FK_ClientCorsOrigin_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.Properties).WithOne(x => x.Client).HasForeignKey(x => x.ClientId)
+            .HasConstraintName("FK_ClientProperty_ClientId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientGrantTypeEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientGrantTypeEntityTypeConfiguration.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientGrantTypeEntityTypeConfiguration : IEntityTypeConfiguration<ClientGrantType>
+{
+    public void Configure(EntityTypeBuilder<ClientGrantType> builder)
+    {
+        builder.Property(x => x.GrantType).HasMaxLength(250).IsRequired();
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientIdPRestrictionEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientIdPRestrictionEntityTypeConfiguration.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientIdPRestrictionEntityTypeConfiguration : IEntityTypeConfiguration<ClientIdPRestriction>
+{
+    public void Configure(EntityTypeBuilder<ClientIdPRestriction> builder)
+    {
+        builder.Property(x => x.Provider).HasMaxLength(200).IsRequired();
+        builder.HasIndex(x => x.ClientId).HasDatabaseName("IX_ClientIdPR_ClientId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientPostLogoutRedirectUriEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientPostLogoutRedirectUriEntityTypeConfiguration.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientPostLogoutRedirectUriEntityTypeConfiguration : IEntityTypeConfiguration<ClientPostLogoutRedirectUri>
+{
+    public void Configure(EntityTypeBuilder<ClientPostLogoutRedirectUri> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.HasIndex(x => x.ClientId).HasDatabaseName("IX_ClientPostLogout_ClientId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientPropertyEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientPropertyEntityTypeConfiguration.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientPropertyEntityTypeConfiguration : IEntityTypeConfiguration<ClientProperty>
+{
+    public void Configure(EntityTypeBuilder<ClientProperty> builder)
+    {
+        builder.Property(x => x.Key).HasMaxLength(250).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(2000).IsRequired();
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientRedirectUriEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientRedirectUriEntityTypeConfiguration.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientRedirectUriEntityTypeConfiguration : IEntityTypeConfiguration<ClientRedirectUri>
+{
+    public void Configure(EntityTypeBuilder<ClientRedirectUri> builder)
+    {
+        builder.Property(x => x.RedirectUri).HasMaxLength(2000).IsRequired();
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientScopeEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientScopeEntityTypeConfiguration.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientScopeEntityTypeConfiguration : IEntityTypeConfiguration<ClientScope>
+{
+    public void Configure(EntityTypeBuilder<ClientScope> builder)
+    {
+        builder.Property(x => x.Scope).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientSecretEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/ClientSecretEntityTypeConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class ClientSecretEntityTypeConfiguration : IEntityTypeConfiguration<ClientSecret>
+{
+    public void Configure(EntityTypeBuilder<ClientSecret> builder)
+    {
+        builder.Property(x => x.Value).HasMaxLength(4000).IsRequired();
+        builder.Property(x => x.Type).HasMaxLength(250).IsRequired();
+        builder.Property(x => x.Description).HasMaxLength(2000).IsRequired(false);
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/DeviceFlowCodesEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/DeviceFlowCodesEntityTypeConfiguration.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class DeviceFlowCodesEntityTypeConfiguration : IEntityTypeConfiguration<DeviceFlowCodes>
+{
+    public void Configure(EntityTypeBuilder<DeviceFlowCodes> builder)
+    {
+        builder.Property(x => x.DeviceCode).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.UserCode).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.SubjectId).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.SessionId).HasMaxLength(100).IsRequired(false);
+        builder.Property(x => x.ClientId).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Description).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.CreationTime).IsRequired();
+        builder.Property(x => x.Expiration).IsRequired();
+        // 50000 chosen to be explicit to allow enough size to avoid truncation, yet stay beneath the MySql row size limit of ~65K
+        // apparently anything over 4K converts to nvarchar(max) on SqlServer
+        builder.Property(x => x.Data).HasMaxLength(50000).IsRequired();
+
+        builder.HasKey(x => new { x.UserCode });
+
+        builder.HasIndex(x => x.DeviceCode).IsUnique().HasFilter("[IsDeleted] = 0").HasDatabaseName("IX_DeviceFlowCode_Code");
+        builder.HasIndex(x => x.Expiration).HasDatabaseName("IX_DeviceFlowCode_Expiration");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/IdentityResourceClaimEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/IdentityResourceClaimEntityTypeConfiguration.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class IdentityResourceClaimEntityTypeConfiguration : IEntityTypeConfiguration<IdentityResourceClaim>
+{
+    public void Configure(EntityTypeBuilder<IdentityResourceClaim> builder)
+    {
+        builder.HasKey(identityResourceClaim => identityResourceClaim.Id);
+        builder.HasOne(x => x.UserClaim).WithMany().HasForeignKey(x => x.UserClaimId)
+            .HasConstraintName("FK_IdResClaim_UserClaimId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasIndex(x => x.IdentityResourceId).HasDatabaseName("IX_IdResourceClaim_ResourceId");
+        builder.HasIndex(x => x.UserClaimId).HasDatabaseName("IX_IdResourceClaim_UserClaimId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/IdentityResourceEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/IdentityResourceEntityTypeConfiguration.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class IdentityResourceEntityTypeConfiguration : IEntityTypeConfiguration<IdentityResource>
+{
+    public void Configure(EntityTypeBuilder<IdentityResource> builder)
+    {
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.DisplayName).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.Description).HasMaxLength(1000).IsRequired(false);
+        builder.HasIndex(x => x.Name).IsUnique().HasFilter("[IsDeleted] = 0").HasDatabaseName("IX_IdResource_Name");
+
+        builder.HasMany(x => x.UserClaims).WithOne(x => x.IdentityResource).HasForeignKey(x => x.IdentityResourceId)
+            .HasConstraintName("FK_IdResClaim_ResourceId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(x => x.Properties).WithOne(x => x.IdentityResource).HasForeignKey(x => x.IdentityResourceId)
+            .HasConstraintName("FK_IdResourceProp_ResourceId").IsRequired().OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/IdentityResourcePropertyEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/IdentityResourcePropertyEntityTypeConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class IdentityResourcePropertyEntityTypeConfiguration : IEntityTypeConfiguration<IdentityResourceProperty>
+{
+    public void Configure(EntityTypeBuilder<IdentityResourceProperty> builder)
+    {
+        builder.Property(x => x.Key).HasMaxLength(250).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(2000).IsRequired();
+        builder.HasIndex(x => x.IdentityResourceId).HasDatabaseName("IX_IdResourceProp_ResourceId");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/PersistedGrantEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/PersistedGrantEntityTypeConfiguration.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class PersistedGrantEntityTypeConfiguration : IEntityTypeConfiguration<PersistedGrant>
+{
+    public void Configure(EntityTypeBuilder<PersistedGrant> builder)
+    {
+        builder.Property(x => x.Key).HasMaxLength(200).ValueGeneratedNever();
+        builder.Property(x => x.Type).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.SubjectId).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.SessionId).HasMaxLength(100).IsRequired(false);
+        builder.Property(x => x.ClientId).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Description).HasMaxLength(200).IsRequired(false);
+        builder.Property(x => x.CreationTime).IsRequired();
+        // 50000 chosen to be explicit to allow enough size to avoid truncation, yet stay beneath the MySql row size limit of ~65K
+        // apparently anything over 4K converts to nvarchar(max) on SqlServer
+        builder.Property(x => x.Data).HasMaxLength(50000).IsRequired();
+
+        builder.HasKey(x => x.Key);
+
+        builder.HasIndex(x => new { x.SubjectId, x.ClientId, x.Type }).HasDatabaseName("IX_PersistedGrant_SCT");
+        builder.HasIndex(x => new { x.SubjectId, x.SessionId, x.Type }).HasDatabaseName("IX_PersistedGrant_SST");
+        builder.HasIndex(x => x.Expiration).HasDatabaseName("IX_PersistedGrant_Expiration");
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/UserClaimEntityTypeConfiguration.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/EntityConfigurations/UserClaimEntityTypeConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.EntityConfigurations;
+
+public class UserClaimEntityTypeConfiguration : IEntityTypeConfiguration<UserClaim>
+{
+    public void Configure(EntityTypeBuilder<UserClaim> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Description).HasMaxLength(1000).IsRequired(false);
+    }
+}

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.csproj
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Masa.Contrib.Authentication.OpenIdConnect.EFCore\Masa.Contrib.Authentication.OpenIdConnect.EFCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.csproj
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Masa.Contrib.Authentication.OpenIdConnect.EFCore\Masa.Contrib.Authentication.OpenIdConnect.EFCore.csproj" />
   </ItemGroup>
 

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/OpenIdConnectEFOracle.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/OpenIdConnectEFOracle.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Reflection;
+
+namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle
+{
+    public class OpenIdConnectEFOracle
+    {
+        public static Assembly Assembly => typeof(OpenIdConnectEFOracle).Assembly;
+    }
+}
+

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/OpenIdConnectEFOracle.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/OpenIdConnectEFOracle.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Reflection;
 
 namespace Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle
 {

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/_Imports.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/_Imports.cs
@@ -1,0 +1,6 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+global using Masa.BuildingBlocks.Authentication.OpenIdConnect.Domain.Entities;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/_Imports.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore.Oracle/_Imports.cs
@@ -4,3 +4,5 @@
 global using Masa.BuildingBlocks.Authentication.OpenIdConnect.Domain.Entities;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.EntityFrameworkCore.Metadata.Builders;
+global using System;
+global using System.Reflection;


### PR DESCRIPTION
# 解决OpenIdConnect在Oracle环境下出现的问题

1、标识符超出30个字符导致无法执行数据库迁移
2、字段必填问题


## Checklist

本地测试成功执行迁移