### PR TITLE
fix(EFCore): Fixed that when the configuration is changed, the data context of the current request is not affected

### DIFF
--- a/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore.Tests/DbContextTest.cs
+++ b/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore.Tests/DbContextTest.cs
@@ -315,4 +315,51 @@ public class DbContextTest : TestBase
         Assert.AreEqual(1, dbConnectionStringProvider.DbContextOptionsList.Count);
         Assert.AreEqual(connectionString, dbConnectionStringProvider.DbContextOptionsList[0].ConnectionString);
     }
+
+    [TestMethod]
+    public async Task TestModifyConnectionString()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", true, true)
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddMasaDbContext<CustomQueryDbContext>(optionsBuilder => optionsBuilder.UseSqlite());
+
+        var serviceProvider = services.BuildServiceProvider();
+        var connectionStringProvider = serviceProvider.GetService<IConnectionStringProvider>();
+        Assert.IsNotNull(connectionStringProvider);
+
+        var connectionString = await connectionStringProvider.GetConnectionStringAsync();
+        Assert.AreEqual("data source=test;", connectionString);
+
+        var rootPath = AppDomain.CurrentDomain.BaseDirectory;
+
+        var expectedNewConnectionString = "data source=test2;";
+        var oldContent = await File.ReadAllTextAsync(Path.Combine(rootPath, "appsettings.json"));
+        await File.WriteAllTextAsync(Path.Combine(rootPath, "appsettings.json"),
+            System.Text.Json.JsonSerializer.Serialize(new
+            {
+                ConnectionStrings = new
+                {
+                    DefaultConnection = expectedNewConnectionString
+                }
+            }));
+
+        await Task.Delay(2000);
+
+        connectionStringProvider = serviceProvider.GetService<IConnectionStringProvider>();
+        Assert.IsNotNull(connectionStringProvider);
+
+        connectionString = await connectionStringProvider.GetConnectionStringAsync();
+        Assert.AreEqual("data source=test;", connectionString);
+
+        connectionStringProvider = serviceProvider.CreateScope().ServiceProvider.GetService<IConnectionStringProvider>();
+        Assert.IsNotNull(connectionStringProvider);
+
+        connectionString = await connectionStringProvider.GetConnectionStringAsync();
+        Assert.AreEqual(expectedNewConnectionString, connectionString);
+
+        await File.WriteAllTextAsync(Path.Combine(rootPath, "appsettings.json"), oldContent);
+    }
 }

--- a/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore.Tests/DefaultConnectionStringProviderTest.cs
+++ b/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore.Tests/DefaultConnectionStringProviderTest.cs
@@ -18,7 +18,7 @@ public class DefaultConnectionStringProviderTest
             };
         });
         var serviceProvider = services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptionsMonitor<MasaDbConnectionOptions>>();
+        var options = serviceProvider.GetRequiredService<IOptionsSnapshot<MasaDbConnectionOptions>>();
         var defaultConnectionStringProvider = new DefaultConnectionStringProvider(options);
         var connectionString = await defaultConnectionStringProvider.GetConnectionStringAsync();
         Assert.AreEqual("Test1", connectionString);
@@ -36,7 +36,7 @@ public class DefaultConnectionStringProviderTest
             };
         });
         var serviceProvider = services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptionsMonitor<MasaDbConnectionOptions>>();
+        var options = serviceProvider.GetRequiredService<IOptionsSnapshot<MasaDbConnectionOptions>>();
         var defaultConnectionStringProvider = new DefaultConnectionStringProvider(options);
         var connectionString = await defaultConnectionStringProvider.GetConnectionStringAsync(string.Empty);
         Assert.AreEqual("Test1", connectionString);

--- a/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore/DbConnectionStringProvider.cs
+++ b/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore/DbConnectionStringProvider.cs
@@ -7,10 +7,10 @@ namespace Microsoft.EntityFrameworkCore;
 
 public class DbConnectionStringProvider : DbConnectionStringProviderBase
 {
-    private readonly IOptionsMonitor<MasaDbConnectionOptions> _options;
+    private readonly IOptionsSnapshot<MasaDbConnectionOptions> _options;
 
-    public DbConnectionStringProvider(IOptionsMonitor<MasaDbConnectionOptions> options) => _options = options;
+    public DbConnectionStringProvider(IOptionsSnapshot<MasaDbConnectionOptions> options) => _options = options;
 
     protected override List<MasaDbContextConfigurationOptions> GetDbContextOptionsList()
-        => _options.CurrentValue.ConnectionStrings.Select(item => new MasaDbContextConfigurationOptions(item.Value)).Distinct().ToList();
+        => _options.Value.ConnectionStrings.Select(item => new MasaDbContextConfigurationOptions(item.Value)).Distinct().ToList();
 }

--- a/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore/DefaultConnectionStringProvider.cs
+++ b/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore/DefaultConnectionStringProvider.cs
@@ -5,17 +5,17 @@ namespace Microsoft.EntityFrameworkCore;
 
 public class DefaultConnectionStringProvider : IConnectionStringProvider
 {
-    private readonly IOptionsMonitor<MasaDbConnectionOptions> _options;
+    private readonly IOptionsSnapshot<MasaDbConnectionOptions> _options;
 
-    public DefaultConnectionStringProvider(IOptionsMonitor<MasaDbConnectionOptions> options) => _options = options;
+    public DefaultConnectionStringProvider(IOptionsSnapshot<MasaDbConnectionOptions> options) => _options = options;
 
     public Task<string> GetConnectionStringAsync(string name = ConnectionStrings.DEFAULT_CONNECTION_STRING_NAME) => Task.FromResult(GetConnectionString(name));
 
     public string GetConnectionString(string name = ConnectionStrings.DEFAULT_CONNECTION_STRING_NAME)
     {
         if (string.IsNullOrEmpty(name))
-            return _options.CurrentValue.ConnectionStrings.DefaultConnection;
+            return _options.Value.ConnectionStrings.DefaultConnection;
 
-        return _options.CurrentValue.ConnectionStrings.GetConnectionString(name);
+        return _options.Value.ConnectionStrings.GetConnectionString(name);
     }
 }

--- a/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Contrib/Data/Orm/EFCore/Masa.Contrib.Data.EFCore/Extensions/ServiceCollectionExtensions.cs
@@ -55,7 +55,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<IConcurrencyStampProvider, DefaultConcurrencyStampProvider>();
         services.TryAddScoped<IConnectionStringProvider, DefaultConnectionStringProvider>();
-        services.TryAddSingleton<IDbConnectionStringProvider, DbConnectionStringProvider>();
+        services.TryAddScoped<IDbConnectionStringProvider, DbConnectionStringProvider>();
 
         services.TryAdd(
             new ServiceDescriptor(

--- a/src/Contrib/Data/UoW/Masa.Contrib.Data.UoW.EFCore/DefaultConnectionStringProvider.cs
+++ b/src/Contrib/Data/UoW/Masa.Contrib.Data.UoW.EFCore/DefaultConnectionStringProvider.cs
@@ -6,12 +6,12 @@ namespace Masa.Contrib.Data.UoW.EFCore;
 public class DefaultConnectionStringProvider : IConnectionStringProvider
 {
     private readonly IUnitOfWorkAccessor _unitOfWorkAccessor;
-    private readonly IOptionsMonitor<MasaDbConnectionOptions> _options;
+    private readonly IOptionsSnapshot<MasaDbConnectionOptions> _options;
     private readonly ILogger<DefaultConnectionStringProvider>? _logger;
 
     public DefaultConnectionStringProvider(
         IUnitOfWorkAccessor unitOfWorkAccessor,
-        IOptionsMonitor<MasaDbConnectionOptions> options,
+        IOptionsSnapshot<MasaDbConnectionOptions> options,
         ILogger<DefaultConnectionStringProvider>? logger = null)
     {
         _unitOfWorkAccessor = unitOfWorkAccessor;
@@ -26,7 +26,7 @@ public class DefaultConnectionStringProvider : IConnectionStringProvider
         if (_unitOfWorkAccessor.CurrentDbContextOptions != null)
             return _unitOfWorkAccessor.CurrentDbContextOptions.ConnectionString;
 
-        var connectionStrings = _options.CurrentValue.ConnectionStrings;
+        var connectionStrings = _options.Value.ConnectionStrings;
         var connectionString = string.IsNullOrEmpty(name) ? connectionStrings.DefaultConnection : connectionStrings.GetConnectionString(name);
         if (string.IsNullOrEmpty(connectionString))
             _logger?.LogError("Failed to get database connection string, please check whether the configuration of IOptionsSnapshot<MasaDbConnectionOptions> is abnormal");

--- a/src/Contrib/Isolation/Masa.Contrib.Isolation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Contrib/Isolation/Masa.Contrib.Isolation/Extensions/ServiceCollectionExtensions.cs
@@ -30,7 +30,7 @@ internal static class ServiceCollectionExtensions
         services
             .TryAddConfigure<IsolationDbConnectionOptions>()
             .AddTransient(typeof(IEventMiddleware<>), typeof(IsolationEventMiddleware<>))
-            .TryAddSingleton<IDbConnectionStringProvider, IsolationDbContextProvider>();
+            .TryAddScoped<IDbConnectionStringProvider, IsolationDbContextProvider>();
 
         if (services.Any(service => service.ServiceType == typeof(IConnectionStringProvider)))
             services.Replace(new ServiceDescriptor(typeof(IConnectionStringProvider), typeof(DefaultDbIsolationConnectionStringProvider),

--- a/src/Contrib/Isolation/Masa.Contrib.Isolation/IsolationDbContextProvider.cs
+++ b/src/Contrib/Isolation/Masa.Contrib.Isolation/IsolationDbContextProvider.cs
@@ -5,18 +5,18 @@ namespace Masa.Contrib.Isolation;
 
 public class IsolationDbContextProvider : DbConnectionStringProviderBase
 {
-    private readonly IOptionsMonitor<IsolationDbConnectionOptions> _options;
+    private readonly IOptionsSnapshot<IsolationDbConnectionOptions> _options;
 
-    public IsolationDbContextProvider(IOptionsMonitor<IsolationDbConnectionOptions> options) => _options = options;
+    public IsolationDbContextProvider(IOptionsSnapshot<IsolationDbConnectionOptions> options) => _options = options;
 
     protected override List<MasaDbContextConfigurationOptions> GetDbContextOptionsList()
     {
-        var connectionStrings = _options.CurrentValue.IsolationConnectionStrings
+        var connectionStrings = _options.Value.IsolationConnectionStrings
             .Select(connectionString => connectionString.ConnectionString)
             .Distinct()
             .ToList();
-        if (!connectionStrings.Contains(_options.CurrentValue.ConnectionStrings.DefaultConnection))
-            connectionStrings.Add(_options.CurrentValue.ConnectionStrings.DefaultConnection);
+        if (!connectionStrings.Contains(_options.Value.ConnectionStrings.DefaultConnection))
+            connectionStrings.Add(_options.Value.ConnectionStrings.DefaultConnection);
 
         return connectionStrings.Select(connectionString => new MasaDbContextConfigurationOptions(connectionString)).ToList();
     }


### PR DESCRIPTION
# Description

Fixed that when the configuration is changed, the data context of the current request is not affected

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
