### PR TITLE
feat:  Utils:  FluentValidation   校验忽略Null值，并且提供WhenNotEmpty方法

### DIFF
--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/FluentValidationExtensions.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/FluentValidationExtensions.cs
@@ -7,37 +7,37 @@ namespace FluentValidation;
 
 public static class FluentValidationExtensions
 {
-    public static IRuleBuilderOptions<T, string> Chinese<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> Chinese<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new ChineseValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> Number<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> Number<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new NumberValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> Letter<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> Letter<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new LetterValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> LowerLetter<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> LowerLetter<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new LowerLetterValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> UpperLetter<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> UpperLetter<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new UpperLetterValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> LetterNumber<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> LetterNumber<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new LetterNumberValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> ChineseLetterUnderline<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> ChineseLetterUnderline<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new ChineseLetterUnderlineValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> ChineseLetter<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> ChineseLetter<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new ChineseLetterValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> ChineseLetterNumberUnderline<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> ChineseLetterNumberUnderline<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new ChineseLetterNumberUnderlineValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> ChineseLetterNumber<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> ChineseLetterNumber<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new ChineseLetterNumberValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> Phone<T>(this IRuleBuilder<T, string> ruleBuilder, string? culture = null)
+    public static IRuleBuilderOptions<T, string?> Phone<T>(this IRuleBuilder<T, string?> ruleBuilder, string? culture = null)
         => ruleBuilder.SetValidator(new PhoneValidator<T>(culture));
 
     /// <summary>
@@ -47,24 +47,24 @@ public static class FluentValidationExtensions
     /// <param name="culture"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static IRuleBuilderOptions<T, string> IdCard<T>(this IRuleBuilder<T, string> ruleBuilder, string? culture = null)
+    public static IRuleBuilderOptions<T, string?> IdCard<T>(this IRuleBuilder<T, string?> ruleBuilder, string? culture = null)
         => ruleBuilder.SetValidator(new IdCardValidator<T>(culture));
 
-    public static IRuleBuilderOptions<T, string> Email<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> Email<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new EmailRegularValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> Url<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> Url<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new UrlValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> Port<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> Port<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new PortValidator<T>());
 
     public static IRuleBuilderOptions<T, TProperty> Required<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
         => ruleBuilder.SetValidator(new RequiredValidator<T, TProperty>());
 
-    public static IRuleBuilderOptions<T, string> Identity<T>(this IRuleBuilder<T, string> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> Identity<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder.SetValidator(new IdentityValidator<T>());
 
-    public static IRuleBuilderOptions<T, string> Password<T>(this IRuleBuilder<T, string> ruleBuilder, string expression = RegularHelper.PASSWORD_REGULAR)
+    public static IRuleBuilderOptions<T, string?> Password<T>(this IRuleBuilder<T, string?> ruleBuilder, string expression = RegularHelper.PASSWORD_REGULAR)
         => ruleBuilder.SetValidator(new PasswordValidator<T>(expression));
 }

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Internal/RegularHelper.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Internal/RegularHelper.cs
@@ -7,26 +7,26 @@ namespace Masa.Utils.Extensions.Validations.FluentValidation;
 
 internal static class RegularHelper
 {
-    internal const string CHINESE = "^\\s{0}$|^[\u4e00-\u9fa5]+$";
-    internal const string NUMBER = "^\\s{0}$|^[0-9]+$";
-    internal const string LETTER = "^\\s{0}$|^[a-zA-Z]+$";
-    internal const string IDENTIFY = "^\\s{0}$|^[a-zA-Z0-9\\.-]+$";
-    internal const string LOWER_LETTER = "^\\s{0}$|^[a-z]+$";
-    internal const string UPPER_LETTER = "^\\s{0}$|^[A-Z]+$";
-    internal const string LETTER_NUMBER = "^\\s{0}$|^[a-zA-Z0-9]+$";
-    internal const string CHINESE_LETTER_NUMBER = "^\\s{0}$|^[\u4e00-\u9fa5a-zA-Z0-9]+$";
-    internal const string CHINESE_LETTER = "^\\s{0}$|^[\u4e00-\u9fa5a-zA-Z]+$";
-    internal const string CHINESE_LETTER_NUMBER_UNDERLINE = "^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9]+$";
-    internal const string CHINESE_LETTER_UNDERLINE = "^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z]+$";
-    internal const string IDCARD = "^\\s{0}$|(^\\d{15}$)|(^\\d{17}([0-9]|X|x)$)";
-    internal const string URL = "^\\s{0}$|[a-zA-z]+://[^s]*";
-    internal const string EMAIL = @"^\s{0}$|^\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$";
+    internal const string CHINESE = "^[\u4e00-\u9fa5]+$";
+    internal const string NUMBER = "^[0-9]+$";
+    internal const string LETTER = "^[a-zA-Z]+$";
+    internal const string IDENTIFY = "^[a-zA-Z0-9\\.-]+$";
+    internal const string LOWER_LETTER = "^[a-z]+$";
+    internal const string UPPER_LETTER = "^[A-Z]+$";
+    internal const string LETTER_NUMBER = "^[a-zA-Z0-9]+$";
+    internal const string CHINESE_LETTER_NUMBER = "^[\u4e00-\u9fa5a-zA-Z0-9]+$";
+    internal const string CHINESE_LETTER = "^[\u4e00-\u9fa5a-zA-Z]+$";
+    internal const string CHINESE_LETTER_NUMBER_UNDERLINE = "^[\u4e00-\u9fa5_a-zA-Z0-9]+$";
+    internal const string CHINESE_LETTER_UNDERLINE = "^[\u4e00-\u9fa5_a-zA-Z]+$";
+    internal const string IDCARD = "(^\\d{15}$)|(^\\d{17}([0-9]|X|x)$)";
+    internal const string URL = "[a-zA-z]+://[^s]*";
+    internal const string EMAIL = @"^\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$";
 #pragma warning disable S2068
-    internal const string PASSWORD_REGULAR = @"^\s{0}$|^\S*(?=\S{6,})(?=\S*\d)(?=\S*[A-Za-z])\S*$";
+    internal const string PASSWORD_REGULAR = @"^\S*(?=\S{6,})(?=\S*\d)(?=\S*[A-Za-z])\S*$";
 #pragma warning restore S2068
 
     internal const string PORT =
-        "^\\s{0}$|^([1-9]|[1-9]\\d|[1-9]\\d{2}|[1-9]\\d{3}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])$";
+        "^([1-9]|[1-9]\\d|[1-9]\\d{2}|[1-9]\\d{3}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])$";
 
     #region Phone
 

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/IdCardValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/IdCardValidator.cs
@@ -5,7 +5,7 @@
 
 namespace FluentValidation.Validators;
 
-public class IdCardValidator<T> : PropertyValidator<T, string>
+public class IdCardValidator<T> : PropertyValidator<T, string?>
 {
     public override string Name => nameof(IdCardValidator<T>);
 
@@ -13,7 +13,7 @@ public class IdCardValidator<T> : PropertyValidator<T, string>
 
     public IdCardValidator(string? culture) => _culture = culture;
 
-    public override bool IsValid(ValidationContext<T> context, string value)
+    public override bool IsValid(ValidationContext<T> context, string? value)
     {
         var provider = GetIIdCardProvider();
         if (value == null) return true;

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/IdCardValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/IdCardValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 // ReSharper disable once CheckNamespace
@@ -14,7 +14,11 @@ public class IdCardValidator<T> : PropertyValidator<T, string>
     public IdCardValidator(string? culture) => _culture = culture;
 
     public override bool IsValid(ValidationContext<T> context, string value)
-        => GetIIdCardProvider().IsValid(value);
+    {
+        var provider = GetIIdCardProvider();
+        if (value == null) return true;
+        return provider.IsValid(value);
+    }
 
     private IIdCardProvider GetIIdCardProvider()
     {

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/MasaAbstractValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/MasaAbstractValidator.cs
@@ -19,17 +19,17 @@ public abstract class MasaAbstractValidator<T> : AbstractValidator<T>
     {
         return When(GetPredicate(selector), () => action.Invoke(RuleFor(validSelector)));
     }
-    protected virtual IConditionBuilder WhenNotEmpty<TProperty>(Expression<Func<T, TProperty>> selector, IPropertyValidator<T, TProperty> validator) where TProperty : class
+    protected virtual IConditionBuilder WhenNotEmpty<TProperty>(Expression<Func<T, TProperty?>> selector, IPropertyValidator<T, TProperty?> validator) where TProperty : class
     {
         return WhenNotEmpty(selector, selector, validator);
     }
 
-    protected virtual IConditionBuilder WhenNotEmpty<TProperty, TValidProperty>(Expression<Func<T, TProperty>> selector, Expression<Func<T, TValidProperty>> validSelector, IPropertyValidator<T, TValidProperty> validator) where TProperty : class
+    protected virtual IConditionBuilder WhenNotEmpty<TProperty, TValidProperty>(Expression<Func<T, TProperty?>> selector, Expression<Func<T, TValidProperty?>> validSelector, IPropertyValidator<T, TValidProperty?> validator) where TProperty : class
     {
         return When(GetPredicate(selector), () => RuleFor(validSelector).SetValidator(validator));
     }
 
-    protected virtual Func<T, bool> GetPredicate<TProperty>(Expression<Func<T, TProperty>> selector)
+    protected virtual Func<T, bool> GetPredicate<TProperty>(Expression<Func<T, TProperty?>> selector)
     {
         var selectorFunc = selector.Compile();
         return value =>

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/MasaAbstractValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/MasaAbstractValidator.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 // ReSharper disable once CheckNamespace
-
-using System;
-using System.Linq.Expressions;
-using static System.Collections.Specialized.BitVector32;
-
 namespace FluentValidation.Validators;
 
 public abstract class MasaAbstractValidator<T> : AbstractValidator<T>
@@ -15,10 +10,12 @@ public abstract class MasaAbstractValidator<T> : AbstractValidator<T>
     {
         return WhenNotEmpty(selector, selector, action);
     }
+
     protected virtual IConditionBuilder WhenNotEmpty<TProperty, TValidProperty>(Expression<Func<T, TProperty?>> selector, Expression<Func<T, TValidProperty?>> validSelector, Action<IRuleBuilderInitial<T, TValidProperty?>> action) where TProperty : class
     {
         return When(GetPredicate(selector), () => action.Invoke(RuleFor(validSelector)));
     }
+
     protected virtual IConditionBuilder WhenNotEmpty<TProperty>(Expression<Func<T, TProperty?>> selector, IPropertyValidator<T, TProperty?> validator) where TProperty : class
     {
         return WhenNotEmpty(selector, selector, validator);

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/MasaAbstractValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/MasaAbstractValidator.cs
@@ -1,0 +1,50 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+// ReSharper disable once CheckNamespace
+
+using System;
+using System.Linq.Expressions;
+using static System.Collections.Specialized.BitVector32;
+
+namespace FluentValidation.Validators;
+
+public abstract class MasaAbstractValidator<T> : AbstractValidator<T>
+{
+    protected virtual IConditionBuilder WhenNotEmpty<TProperty>(Expression<Func<T, TProperty?>> selector, Action<IRuleBuilderInitial<T, TProperty?>> action) where TProperty : class
+    {
+        return WhenNotEmpty(selector, selector, action);
+    }
+    protected virtual IConditionBuilder WhenNotEmpty<TProperty, TValidProperty>(Expression<Func<T, TProperty?>> selector, Expression<Func<T, TValidProperty?>> validSelector, Action<IRuleBuilderInitial<T, TValidProperty?>> action) where TProperty : class
+    {
+        return When(GetPredicate(selector), () => action.Invoke(RuleFor(validSelector)));
+    }
+    protected virtual IConditionBuilder WhenNotEmpty<TProperty>(Expression<Func<T, TProperty>> selector, IPropertyValidator<T, TProperty> validator) where TProperty : class
+    {
+        return WhenNotEmpty(selector, selector, validator);
+    }
+
+    protected virtual IConditionBuilder WhenNotEmpty<TProperty, TValidProperty>(Expression<Func<T, TProperty>> selector, Expression<Func<T, TValidProperty>> validSelector, IPropertyValidator<T, TValidProperty> validator) where TProperty : class
+    {
+        return When(GetPredicate(selector), () => RuleFor(validSelector).SetValidator(validator));
+    }
+
+    protected virtual Func<T, bool> GetPredicate<TProperty>(Expression<Func<T, TProperty>> selector)
+    {
+        var selectorFunc = selector.Compile();
+        return value =>
+        {
+            var propertyValue = selectorFunc(value);
+            switch (propertyValue)
+            {
+                case null:
+                case string s when string.IsNullOrWhiteSpace(s):
+                case System.Collections.ICollection { Count: 0 }:
+                case Array { Length: 0 }:
+                case System.Collections.IEnumerable e when !e.GetEnumerator().MoveNext():
+                    return false;
+            }
+            return !EqualityComparer<TProperty>.Default.Equals(propertyValue, default);
+        };
+    }
+}

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/PasswordValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/PasswordValidator.cs
@@ -3,7 +3,7 @@
 
 namespace FluentValidation.Validators;
 
-public class PasswordValidator<T> : RegularExpressionValidator<T>
+public class PasswordValidator<T> : MasaRegularExpressionValidator<T>
 {
     public override string Name => nameof(PasswordValidator<T>);
 

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/PhoneValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/PhoneValidator.cs
@@ -5,7 +5,7 @@
 
 namespace FluentValidation.Validators;
 
-public class PhoneValidator<T> : PropertyValidator<T, string>
+public class PhoneValidator<T> : PropertyValidator<T, string?>
 {
     private readonly string? _culture;
 

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/PhoneValidator.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/Validators/PhoneValidator.cs
@@ -17,14 +17,15 @@ public class PhoneValidator<T> : PropertyValidator<T, string>
     {
         var regex = CreateRegex(GetExpression(_culture));
 
-        if (value != null && !regex.IsMatch(value))
+        if (value == null)
+        {
+            return true;
+        }
+        if (!regex.IsMatch(value))
         {
             context.MessageFormatter.AppendArgument("RegularExpression", regex.ToString());
             return false;
         }
-
-        if (value == null) return false;
-
         var result = regex.Match(value);
         return result.Value == value;
     }

--- a/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/_Imports.cs
+++ b/src/Utils/Extensions/Validations/Masa.Utils.Extensions.Validations.FluentValidation/_Imports.cs
@@ -1,6 +1,7 @@
 // Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+global using System.Linq.Expressions;
 global using FluentValidation.Validators;
 global using Masa.Utils.Extensions.Validations.FluentValidation;
 global using System.Text.RegularExpressions;

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberUnderlineValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberUnderlineValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -16,6 +16,8 @@ public class ChineseLetterNumberUnderlineValidatorTest : ValidatorBaseTest
     [DataRow(".", false)]
     [DataRow("123.", false)]
     [DataRow("123_", true)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestChineseLetterNumberUnderline(string name, bool expectedResult)
     {
@@ -31,7 +33,7 @@ public class ChineseLetterNumberUnderlineValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberUnderlineValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberUnderlineValidatorTest.cs
@@ -19,7 +19,7 @@ public class ChineseLetterNumberUnderlineValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestChineseLetterNumberUnderline(string name, bool expectedResult)
+    public void TestChineseLetterNumberUnderline(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberValidatorTest.cs
@@ -15,6 +15,8 @@ public class ChineseLetterNumberValidatorTest : ValidatorBaseTest
     [DataRow("masastack123", true)]
     [DataRow(".", false)]
     [DataRow("123.", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestChineseLetterNumber(string name, bool expectedResult)
     {
@@ -30,7 +32,7 @@ public class ChineseLetterNumberValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterNumberValidatorTest.cs
@@ -18,7 +18,7 @@ public class ChineseLetterNumberValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestChineseLetterNumber(string name, bool expectedResult)
+    public void TestChineseLetterNumber(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterUnderlineValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterUnderlineValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -16,6 +16,8 @@ public class ChineseLetterUnderlineValidatorTest : ValidatorBaseTest
     [DataRow("团队123", false)]
     [DataRow("团队_", true)]
     [DataRow("_", true)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestChineseLetterUnderline(string name, bool expectedResult)
     {
@@ -31,7 +33,7 @@ public class ChineseLetterUnderlineValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterUnderlineValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterUnderlineValidatorTest.cs
@@ -19,7 +19,7 @@ public class ChineseLetterUnderlineValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestChineseLetterUnderline(string name, bool expectedResult)
+    public void TestChineseLetterUnderline(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -29,7 +29,7 @@ public class ChineseLetterValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseLetterValidatorTest.cs
@@ -14,8 +14,10 @@ public class ChineseLetterValidatorTest : ValidatorBaseTest
     [DataRow("123", false)]
     [DataRow("masastack123", false)]
     [DataRow("团队123", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
-    public void TestChineseLetter(string name, bool expectedResult)
+    public void TestChineseLetter(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseValidatorTest.cs
@@ -17,7 +17,7 @@ public class ChineseValidatorTest: ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestChinese(string name, bool expectedResult)
+    public void TestChinese(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/ChineseValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -14,6 +14,8 @@ public class ChineseValidatorTest: ValidatorBaseTest
     [DataRow("123", false)]
     [DataRow("masastack123", false)]
     [DataRow("团队123", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestChinese(string name, bool expectedResult)
     {
@@ -29,7 +31,7 @@ public class ChineseValidatorTest: ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/EmailValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/EmailValidatorTest.cs
@@ -14,7 +14,7 @@ public class EmailValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestEmail(string email, bool expectedResult)
+    public void TestEmail(string? email, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/EmailValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/EmailValidatorTest.cs
@@ -11,6 +11,8 @@ public class EmailValidatorTest : ValidatorBaseTest
     [DataRow("masastack123@", false)]
     [DataRow("123", false)]
     [DataRow("123@qq.com", true)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestEmail(string email, bool expectedResult)
     {
@@ -26,7 +28,7 @@ public class EmailValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/Events/RegisterPortEvent.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/Events/RegisterPortEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 // ReSharper disable once CheckNamespace
@@ -7,5 +7,5 @@ namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
 
 public class RegisterPortEvent
 {
-    public string Port { get; set; }
+    public string? Port { get; set; }
 }

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/Events/RegisterUserEvent.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/Events/RegisterUserEvent.cs
@@ -9,6 +9,8 @@ public class RegisterUserEvent
 {
     public string? Name { get; set; }
 
+    public string? Identity { get; set; }
+
     public string? IdCard { get; set; }
 
     public string? Phone { get; set; }

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/Events/RegisterUserEvent.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/Events/RegisterUserEvent.cs
@@ -7,19 +7,19 @@ namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
 
 public class RegisterUserEvent
 {
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public string IdCard { get; set; }
+    public string? IdCard { get; set; }
 
-    public string Phone { get; set; }
+    public string? Phone { get; set; }
 
-    public string Port { get; set; }
+    public string? Port { get; set; }
 
-    public string Referer { get; set; }
+    public string? Referer { get; set; }
 
     public string? Remark { get; set; }
 
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
-    public string Password { get; set; }
+    public string? Password { get; set; }
 }

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
@@ -13,7 +13,7 @@ public class IdCardOptionalValidatorTest : ValidatorBaseTest
     [DataRow("", true)]
     [DataRow(null, true)]
     [DataTestMethod]
-    public void TestIdCard(string idCard, bool expectedResult)
+    public void TestIdCard(string? idCard, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator("zh-CN");
         var result = validator.Validate(new RegisterUserEvent()
@@ -31,7 +31,7 @@ public class IdCardOptionalValidatorTest : ValidatorBaseTest
     [DataRow("110101192803011819")]
     [DataRow("")]
     [TestMethod]
-    public void TestIdCardByUs(string idCard)
+    public void TestIdCardByUs(string? idCard)
     {
         var validator = new RegisterUserEventValidator("en-US");
         switch (idCard)

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
@@ -38,12 +38,10 @@ public class IdCardOptionalValidatorTest : ValidatorBaseTest
         {
             case null:
             case "":
-#pragma warning disable CS8601 // 引用类型赋值可能为 null。
                 var result = validator.Validate(new RegisterUserEvent()
                 {
                     IdCard = idCard
                 });
-#pragma warning restore CS8601 // 引用类型赋值可能为 null。
                 Assert.IsTrue(result.IsValid);
                 break;
             default:

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
@@ -38,10 +38,12 @@ public class IdCardOptionalValidatorTest : ValidatorBaseTest
         {
             case null:
             case "":
+#pragma warning disable CS8601 // 引用类型赋值可能为 null。
                 var result = validator.Validate(new RegisterUserEvent()
                 {
                     IdCard = idCard
                 });
+#pragma warning restore CS8601 // 引用类型赋值可能为 null。
                 Assert.IsTrue(result.IsValid);
                 break;
             default:

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardOptionalValidatorTest.cs
@@ -4,14 +4,14 @@
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
 
 [TestClass]
-public class IdCardValidatorTest : ValidatorBaseTest
+public class IdCardOptionalValidatorTest : ValidatorBaseTest
 {
     public override string Message => "'Id Card' is not a valid ID.";
 
     [DataRow("410785195212123541", false)]
     [DataRow("110101192803011819", true)]
+    [DataRow("", true)]
     [DataRow(null, true)]
-    [DataRow("", false)]
     [DataTestMethod]
     public void TestIdCard(string idCard, bool expectedResult)
     {
@@ -26,6 +26,7 @@ public class IdCardValidatorTest : ValidatorBaseTest
             Assert.AreEqual(Message, result.Errors[0].ErrorMessage);
         }
     }
+
     [DataRow(null)]
     [DataRow("110101192803011819")]
     [DataRow("")]
@@ -33,17 +34,30 @@ public class IdCardValidatorTest : ValidatorBaseTest
     public void TestIdCardByUs(string idCard)
     {
         var validator = new RegisterUserEventValidator("en-US");
-        Assert.ThrowsException<NotSupportedException>(() => validator.Validate(new RegisterUserEvent()
+        switch (idCard)
         {
-            IdCard = idCard
-        }));
+            case null:
+            case "":
+                var result = validator.Validate(new RegisterUserEvent()
+                {
+                    IdCard = idCard
+                });
+                Assert.IsTrue(result.IsValid);
+                break;
+            default:
+                Assert.ThrowsException<NotSupportedException>(() => validator.Validate(new RegisterUserEvent()
+                {
+                    IdCard = idCard
+                }));
+                break;
+        }
     }
 
     public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
-        public RegisterUserEventValidator(string culture)
+        public RegisterUserEventValidator(string? culture = null)
         {
-            RuleFor(r => r.IdCard).IdCard(culture);
+            _ = WhenNotEmpty(r => r.IdCard, new IdCardValidator<RegisterUserEvent>(culture));
         }
     }
 }

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdCardValidatorTest.cs
@@ -13,7 +13,7 @@ public class IdCardValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestIdCard(string idCard, bool expectedResult)
+    public void TestIdCard(string? idCard, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator("zh-CN");
         var result = validator.Validate(new RegisterUserEvent()
@@ -30,7 +30,7 @@ public class IdCardValidatorTest : ValidatorBaseTest
     [DataRow("110101192803011819")]
     [DataRow("")]
     [TestMethod]
-    public void TestIdCardByUs(string idCard)
+    public void TestIdCardByUs(string? idCard)
     {
         var validator = new RegisterUserEventValidator("en-US");
         Assert.ThrowsException<NotSupportedException>(() => validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdentityValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdentityValidatorTest.cs
@@ -26,7 +26,7 @@ public class IdentityValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class IdentityValidator : AbstractValidator<string>
+    public class IdentityValidator : MasaAbstractValidator<string>
     {
         public IdentityValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdentityValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/IdentityValidatorTest.cs
@@ -1,12 +1,14 @@
 // Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+using System.Xml.Linq;
+
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
 
 [TestClass]
 public class IdentityValidatorTest : ValidatorBaseTest
 {
-    public override string Message => "'' must be numbers, letters or . and - .";
+    public override string Message => "'Identity' must be numbers, letters or . and - .";
 
     [DataRow("Masa团队", false)]
     [DataRow("masastack", true)]
@@ -14,11 +16,16 @@ public class IdentityValidatorTest : ValidatorBaseTest
     [DataRow("Masa", true)]
     [DataRow("123#", false)]
     [DataRow("123.", true)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
-    public void TestIdentity(string identity, bool expectedResult)
+    public void TestIdentity(string? identity, bool expectedResult)
     {
         var validator = new IdentityValidator();
-        var result = validator.Validate(identity);
+        var result = validator.Validate(new RegisterUserEvent()
+        {
+            Identity = identity,
+        });
         Assert.AreEqual(expectedResult, result.IsValid);
         if (!expectedResult)
         {
@@ -26,11 +33,11 @@ public class IdentityValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class IdentityValidator : MasaAbstractValidator<string>
+    public class IdentityValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public IdentityValidator()
         {
-            RuleFor(r => r).Identity();
+            RuleFor(r => r.Identity).Identity();
         }
     }
 }

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterNumberValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterNumberValidatorTest.cs
@@ -17,7 +17,7 @@ public class LetterNumberValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestLetterNumber(string name, bool expectedResult)
+    public void TestLetterNumber(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterNumberValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterNumberValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -14,6 +14,8 @@ public class LetterNumberValidatorTest : ValidatorBaseTest
     [DataRow("123", true)]
     [DataRow("masastack123", true)]
     [DataRow("团队123", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestLetterNumber(string name, bool expectedResult)
     {
@@ -29,7 +31,7 @@ public class LetterNumberValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterValidatorTest.cs
@@ -17,7 +17,7 @@ public class LetterValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestLetterNumber(string name, bool expectedResult)
+    public void TestLetterNumber(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LetterValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -14,6 +14,8 @@ public class LetterValidatorTest : ValidatorBaseTest
     [DataRow("123", false)]
     [DataRow("masastack123", false)]
     [DataRow("Masa", true)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestLetterNumber(string name, bool expectedResult)
     {
@@ -29,7 +31,7 @@ public class LetterValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LowerLetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LowerLetterValidatorTest.cs
@@ -19,7 +19,7 @@ public class LowerLetterValidatorTest: ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestLowerLetter(string name, bool expectedResult)
+    public void TestLowerLetter(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LowerLetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/LowerLetterValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -16,6 +16,8 @@ public class LowerLetterValidatorTest: ValidatorBaseTest
     [DataRow("masa", true)]
     [DataRow("MASA", false)]
     [DataRow("Masa", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestLowerLetter(string name, bool expectedResult)
     {
@@ -31,7 +33,7 @@ public class LowerLetterValidatorTest: ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/NumberValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/NumberValidatorTest.cs
@@ -18,6 +18,8 @@ public class NumberValidatorTest : ValidatorBaseTest
     [DataRow("Masa123", false)]
     [DataRow("123", true)]
     [DataRow("123.", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestNumber(string idCard, bool expectedResult)
     {
@@ -33,7 +35,7 @@ public class NumberValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/NumberValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/NumberValidatorTest.cs
@@ -21,7 +21,7 @@ public class NumberValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestNumber(string idCard, bool expectedResult)
+    public void TestNumber(string? idCard, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PasswordValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PasswordValidatorTest.cs
@@ -15,6 +15,8 @@ public class PasswordValidatorTest : ValidatorBaseTest
     [DataRow("Masa@123", true)]
     [DataRow("123", false)]
     [DataRow("123.", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestPassword(string pwd, bool expectedResult)
     {
@@ -30,7 +32,7 @@ public class PasswordValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PasswordValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PasswordValidatorTest.cs
@@ -18,7 +18,7 @@ public class PasswordValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestPassword(string pwd, bool expectedResult)
+    public void TestPassword(string? pwd, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneOptionalValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneOptionalValidatorTest.cs
@@ -19,7 +19,7 @@ public class PhoneOptionalValidatorTest : ValidatorBaseTest
     [DataRow("8613677777777", "en-US", false)]
     [DataRow("+11021021521", "en-US", false)]
     [DataTestMethod]
-    public void TestPhone(string phone, string? culture, bool expectedResult)
+    public void TestPhone(string? phone, string? culture, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator(culture);
         var result = validator.Validate(new RegisterUserEvent()
@@ -37,7 +37,7 @@ public class PhoneOptionalValidatorTest : ValidatorBaseTest
     [DataRow("133333")]
     [DataRow("")]
     [TestMethod]
-    public void TestPhoneByJapan(string phone)
+    public void TestPhoneByJapan(string? phone)
     {
         string culture = "ja-jp";
         var validator = new RegisterUserEventValidator(culture);

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneOptionalValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneOptionalValidatorTest.cs
@@ -67,7 +67,7 @@ public class PhoneOptionalValidatorTest : ValidatorBaseTest
         {
             //_ = WhenNotEmpty(r => r.Phone, r => r.Phone, new PhoneValidator<RegisterUserEvent>(culture));
             //_ = WhenNotEmpty(r => r.Phone, new PhoneValidator<RegisterUserEvent>(culture));
-            _ = WhenNotEmpty(r => r.Phone, rule => rule!.Phone(culture));
+            _ = WhenNotEmpty(r => r.Phone, rule => rule.Phone(culture));
         }
     }
 }

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneOptionalValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneOptionalValidatorTest.cs
@@ -4,7 +4,7 @@
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
 
 [TestClass]
-public class PhoneValidatorTest: ValidatorBaseTest
+public class PhoneOptionalValidatorTest : ValidatorBaseTest
 {
     public override string Message => "'Phone' must be a valid mobile phone number.";
 
@@ -14,7 +14,7 @@ public class PhoneValidatorTest: ValidatorBaseTest
     [DataRow("8613677777777", "zh-CN", true)]
     [DataRow("18613677777777", "zh-CN", false)]
     [DataRow(null, "zh-CN", true)]
-    [DataRow("", "zh-CN", false)]
+    [DataRow("", "zh-CN", true)]
     [DataRow("+19104521452", "en-US", true)]
     [DataRow("8613677777777", "en-US", false)]
     [DataRow("+11021021521", "en-US", false)]
@@ -33,26 +33,41 @@ public class PhoneValidatorTest: ValidatorBaseTest
         }
     }
 
+    [DataRow(null)]
+    [DataRow("133333")]
+    [DataRow("")]
     [TestMethod]
-    public void TestPhoneByJapan()
+    public void TestPhoneByJapan(string phone)
     {
-        string phone="";
-        string culture="ja-jp";
+        string culture = "ja-jp";
         var validator = new RegisterUserEventValidator(culture);
-        Assert.ThrowsException<NotSupportedException>(() =>
+
+        switch (phone)
         {
-            validator.Validate(new RegisterUserEvent()
-            {
-                Phone = phone
-            });
-        });
+            case null:
+            case "":
+                var result = validator.Validate(new RegisterUserEvent()
+                {
+                    Phone = phone
+                });
+                Assert.IsTrue(result.IsValid);
+                break;
+            default:
+                Assert.ThrowsException<NotSupportedException>(() => validator.Validate(new RegisterUserEvent()
+                {
+                    Phone = phone
+                }));
+                break;
+        }
     }
 
     public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator(string? culture)
         {
-            RuleFor(r => r.Phone).Phone(culture);
+            //_ = WhenNotEmpty(r => r.Phone, r => r.Phone, new PhoneValidator<RegisterUserEvent>(culture));
+            //_ = WhenNotEmpty(r => r.Phone, new PhoneValidator<RegisterUserEvent>(culture));
+            _ = WhenNotEmpty(r => r.Phone, rule => rule!.Phone(culture));
         }
     }
 }

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PhoneValidatorTest.cs
@@ -19,7 +19,7 @@ public class PhoneValidatorTest: ValidatorBaseTest
     [DataRow("8613677777777", "en-US", false)]
     [DataRow("+11021021521", "en-US", false)]
     [DataTestMethod]
-    public void TestPhone(string phone, string? culture, bool expectedResult)
+    public void TestPhone(string? phone, string? culture, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator(culture);
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PortValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PortValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -27,7 +27,7 @@ public class PortValidatorTest: ValidatorBaseTest
         }
     }
 
-    public class RegisterPortEventValidator : AbstractValidator<RegisterPortEvent>
+    public class RegisterPortEventValidator : MasaAbstractValidator<RegisterPortEvent>
     {
         public RegisterPortEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PortValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/PortValidatorTest.cs
@@ -13,7 +13,7 @@ public class PortValidatorTest: ValidatorBaseTest
     [DataRow("65535", true)]
     [DataRow("65536", false)]
     [DataTestMethod]
-    public void TestPhone(string port, bool expectedResult)
+    public void TestPhone(string? port, bool expectedResult)
     {
         var validator = new RegisterPortEventValidator();
         var result = validator.Validate(new RegisterPortEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/RequiredValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/RequiredValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -37,7 +37,7 @@ public class RequiredValidatorTest: ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UpperLetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UpperLetterValidatorTest.cs
@@ -19,7 +19,7 @@ public class UpperLetterValidatorTest : ValidatorBaseTest
     [DataRow(null, true)]
     [DataRow("", false)]
     [DataTestMethod]
-    public void TestLowerLetter(string name, bool expectedResult)
+    public void TestLowerLetter(string? name, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UpperLetterValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UpperLetterValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -16,6 +16,8 @@ public class UpperLetterValidatorTest : ValidatorBaseTest
     [DataRow("masa", false)]
     [DataRow("MASA", true)]
     [DataRow("Masa", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataTestMethod]
     public void TestLowerLetter(string name, bool expectedResult)
     {
@@ -31,7 +33,7 @@ public class UpperLetterValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UrlValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UrlValidatorTest.cs
@@ -22,7 +22,7 @@ public class UrlValidatorTest : ValidatorBaseTest
     [DataRow("http://github.com/masastack", true)]
     [DataRow("github.com", false)]
     [DataTestMethod]
-    public void TestLowerLetter(string url, bool expectedResult)
+    public void TestLowerLetter(string? url, bool expectedResult)
     {
         var validator = new RegisterUserEventValidator();
         var result = validator.Validate(new RegisterUserEvent()

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UrlValidatorTest.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/UrlValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Utils.Extensions.Validations.FluentValidation.Tests;
@@ -15,6 +15,8 @@ public class UrlValidatorTest : ValidatorBaseTest
     [DataRow("masastack123", false)]
     [DataRow("masa", false)]
     [DataRow("MASA", false)]
+    [DataRow(null, true)]
+    [DataRow("", false)]
     [DataRow("Masa", false)]
     [DataRow("https://github.com/masastack", true)]
     [DataRow("http://github.com/masastack", true)]
@@ -34,7 +36,7 @@ public class UrlValidatorTest : ValidatorBaseTest
         }
     }
 
-    public class RegisterUserEventValidator : AbstractValidator<RegisterUserEvent>
+    public class RegisterUserEventValidator : MasaAbstractValidator<RegisterUserEvent>
     {
         public RegisterUserEventValidator()
         {

--- a/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/_Imports.cs
+++ b/src/Utils/Extensions/Validations/Tests/Masa.Utils.Extensions.Validations.FluentValidation.Tests/_Imports.cs
@@ -3,5 +3,6 @@
 
 global using FluentValidation;
 global using FluentValidation.Resources;
+global using FluentValidation.Validators;
 global using Microsoft.VisualStudio.TestTools.UnitTesting;
 global using System.Globalization;


### PR DESCRIPTION


# Description

1. 添加`MasaAbstractValidator<T>` 抽象类，封装官方的When，提供WhenNotEmpty方法
2.  `IdCardValidator` 和 `PhoneValidator` 不再校验NULL值
3. 对应调整单元测试
4. 修改`PasswordValidator` 基类为 `MasaRegularExpressionValidator`

# BREAKING CHANGE:

- `IdCardValidator` and `PhoneValidator` 在传入的值是Null的时候，将会通过校验，保持与官方内置验证器的一致逻辑

- 修改 `Masa.Utils.Extensions.Validations.FluentValidation.RegularHelper` 正则表达式 ,取消忽略空字符串的正则。

## Issue reference

close #479 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation  
