### PR TITLE
fix:'DistributedCacheClientFactoryBase,MultilevelCacheClientFactoryBase' class name is inappropriate

### DIFF
--- a/src/BuildingBlocks/Caching/Masa.BuildingBlocks.Caching/Default/DistributedCacheClientFactory.cs
+++ b/src/BuildingBlocks/Caching/Masa.BuildingBlocks.Caching/Default/DistributedCacheClientFactory.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.BuildingBlocks.Caching;
 
-public class DistributedCacheClientFactoryBase : CacheClientFactoryBase<IDistributedCacheClient>, IDistributedCacheClientFactory
+public class DistributedCacheClientFactory : CacheClientFactoryBase<IDistributedCacheClient>, IDistributedCacheClientFactory
 {
     protected override string DefaultServiceNotFoundMessage
         => "Default DistributedCache not found, you need to add it, like services.AddStackExchangeRedisCache()";
@@ -14,7 +14,7 @@ public class DistributedCacheClientFactoryBase : CacheClientFactoryBase<IDistrib
 
     private readonly IOptionsMonitor<DistributedCacheFactoryOptions> _optionsMonitor;
 
-    public DistributedCacheClientFactoryBase(IServiceProvider serviceProvider) : base(serviceProvider)
+    public DistributedCacheClientFactory(IServiceProvider serviceProvider) : base(serviceProvider)
     {
         _optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<DistributedCacheFactoryOptions>>();
     }

--- a/src/BuildingBlocks/Caching/Masa.BuildingBlocks.Caching/Default/MultilevelCacheClientFactory.cs
+++ b/src/BuildingBlocks/Caching/Masa.BuildingBlocks.Caching/Default/MultilevelCacheClientFactory.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.BuildingBlocks.Caching;
 
-public class MultilevelCacheClientFactoryBase : CacheClientFactoryBase<IMultilevelCacheClient>, IMultilevelCacheClientFactory
+public class MultilevelCacheClientFactory : CacheClientFactoryBase<IMultilevelCacheClient>, IMultilevelCacheClientFactory
 {
     protected override string DefaultServiceNotFoundMessage
         => "Default MultilevelCache not found, you need to add it, like services.AddMultilevelCache()";
@@ -14,7 +14,7 @@ public class MultilevelCacheClientFactoryBase : CacheClientFactoryBase<IMultilev
 
     private readonly IOptionsMonitor<MultilevelCacheFactoryOptions> _optionsMonitor;
 
-    public MultilevelCacheClientFactoryBase(IServiceProvider serviceProvider) : base(serviceProvider)
+    public MultilevelCacheClientFactory(IServiceProvider serviceProvider) : base(serviceProvider)
     {
         _optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<MultilevelCacheFactoryOptions>>();
     }

--- a/src/BuildingBlocks/Caching/Masa.BuildingBlocks.Caching/Extensions/ServiceCollectionExtensions.Core.cs
+++ b/src/BuildingBlocks/Caching/Masa.BuildingBlocks.Caching/Extensions/ServiceCollectionExtensions.Core.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection TryAddDistributedCacheCore(IServiceCollection services, string name)
     {
         MasaApp.TrySetServiceCollection(services);
-        services.TryAddSingleton<IDistributedCacheClientFactory, DistributedCacheClientFactoryBase>();
+        services.TryAddSingleton<IDistributedCacheClientFactory, DistributedCacheClientFactory>();
         services.TryAddSingleton(serviceProvider
             => serviceProvider.GetRequiredService<IDistributedCacheClientFactory>().Create());
 
@@ -23,7 +23,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection TryAddMultilevelCacheCore(IServiceCollection services, string name)
     {
         MasaApp.TrySetServiceCollection(services);
-        services.TryAddSingleton<IMultilevelCacheClientFactory, MultilevelCacheClientFactoryBase>();
+        services.TryAddSingleton<IMultilevelCacheClientFactory, MultilevelCacheClientFactory>();
         services.TryAddSingleton(serviceProvider
             => serviceProvider.GetRequiredService<IMultilevelCacheClientFactory>().Create());
 


### PR DESCRIPTION
The name of 'DistributedCacheClientFactoryBase' looks like an abstract class, and I think 'DistributedCacheClientFactory' is a good name for it.