### PR TITLE
fix(tsc): fix record body bug in tracing

### DIFF
--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Extensions/StreamExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Extensions/StreamExtensions.cs
@@ -2,48 +2,70 @@
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
 // ReSharper disable once CheckNamespace
+
 namespace System.IO;
 
 internal static class StreamExtensions
 {
     private static readonly Encoding _defaultEncoding = Encoding.UTF8;
 
-    public static async Task<string?> ReadAsStringAsync(this Stream stream, Encoding? encoding = null,int bufferSize=1024)
+    public static async Task<(long, string?)> ReadAsStringAsync(this Stream stream, Encoding? encoding = null, int bufferSize = 4096)
     {
         if (stream == null)
-            return null;
+            return (-1, null);
 
         if (!stream.CanRead)
-            return "cann't read";
+            return (-1, "cann't read");
 
         if (!stream.CanSeek)
-            return "cann't seek";
+            return (-1, "cann't seek");
 
-        var start = (int)stream.Position;
-        List<byte> data = new();
-        var buffer = new byte[bufferSize];
-        do
-        {
-            var count = await stream.ReadAsync(buffer, 0, buffer.Length);
-            if (count <= 0)
-                break;
-            if (buffer.Length - count == 0)
-            {
-                data.AddRange(buffer);
-            }
-            else
-            {
-                data.AddRange(buffer[0..count]);
-                break;
-            }
-        } while (true);
+        var start = stream.Position;
 
-        if (data.Count > 0)
+        try
         {
-            stream.Seek(start, SeekOrigin.Begin);
-            return (encoding ?? _defaultEncoding).GetString(data.ToArray());
+            List<byte> data = new();
+            var buffer = new byte[bufferSize];
+            stream.Seek(0, SeekOrigin.Begin);
+
+            do
+            {
+                var count = await stream.ReadAsync(buffer, 0, bufferSize);
+                if (count <= 0)
+                    break;
+                if (bufferSize - count == 0)
+                {
+                    data.AddRange(buffer);
+                }
+                else
+                {
+                    data.AddRange(buffer[0..count]);
+                    break;
+                }
+            } while (true);
+
+            if (data.Count > 0)
+            {
+                if (data.Count - OpenTelemetryInstrumentationOptions.MaxBodySize > 0)
+                {
+                    return (data.Count, Convert.ToBase64String(data.ToArray()));
+                }
+                else
+                {
+                    return (data.Count, (encoding ?? _defaultEncoding).GetString(data.ToArray()));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            OpenTelemetryInstrumentationOptions.Logger?.LogError("ReadAsStringAsync", ex);
+        }
+        finally
+        {
+            if (stream != null && stream.CanSeek)
+                stream.Seek(start, SeekOrigin.Begin);
         }
 
-        return null;
+        return (-1, null);
     }
 }

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
@@ -16,7 +16,7 @@ public static class ActivityExtension
         {
             if (!httpRequest.Body.CanSeek)
                 httpRequest.EnableBuffering();
-            SetActivityBody(activity, httpRequest.Body, GetHttpRequestEncoding(httpRequest)).ConfigureAwait(false).GetAwaiter().GetResult(); ;
+            SetActivityBody(activity, httpRequest.Body, GetHttpRequestEncoding(httpRequest)).ConfigureAwait(false).GetAwaiter().GetResult();
         }
         activity.SetTag(OpenTelemetryAttributeName.Host.NAME, Dns.GetHostName());
         return activity;
@@ -29,7 +29,7 @@ public static class ActivityExtension
 
         if (httpRequest.Content is not null)
         {
-            SetActivityBody(activity, httpRequest.Content.ReadAsStream(), GetHttpRequestMessageEncoding(httpRequest)).ConfigureAwait(false).GetAwaiter().GetResult(); ;
+            SetActivityBody(activity, httpRequest.Content.ReadAsStream(), GetHttpRequestMessageEncoding(httpRequest)).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         return activity;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
@@ -16,7 +16,7 @@ public static class ActivityExtension
         {
             if (!httpRequest.Body.CanSeek)
                 httpRequest.EnableBuffering();
-            SetActivityBody(activity, httpRequest.Body, GetHttpRequestEncoding(httpRequest)).ConfigureAwait(false);
+            SetActivityBody(activity, httpRequest.Body, GetHttpRequestEncoding(httpRequest)).ConfigureAwait(false).GetAwaiter().GetResult(); ;
         }
         activity.SetTag(OpenTelemetryAttributeName.Host.NAME, Dns.GetHostName());
         return activity;
@@ -29,7 +29,7 @@ public static class ActivityExtension
 
         if (httpRequest.Content is not null)
         {
-            SetActivityBody(activity, httpRequest.Content.ReadAsStream(), GetHttpRequestMessageEncoding(httpRequest)).ConfigureAwait(false);
+            SetActivityBody(activity, httpRequest.Content.ReadAsStream(), GetHttpRequestMessageEncoding(httpRequest)).ConfigureAwait(false).GetAwaiter().GetResult(); ;
         }
 
         return activity;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
@@ -93,10 +93,10 @@ public static class ActivityExtension
         (long length, string? body) = await inputSteam.ReadAsStringAsync(encoding);
 
         if (length <= 0)
-            return;        
+            return;
         if (length - OpenTelemetryInstrumentationOptions.MaxBodySize > 0)
         {
-            OpenTelemetryInstrumentationOptions.Logger?.LogInformation(body);
+            OpenTelemetryInstrumentationOptions.Logger?.LogInformation("Request body in base64 encode:{Body}", body);
         }
         else
         {

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
@@ -29,7 +29,7 @@ public static class ActivityExtension
 
         if (httpRequest.Content is not null)
         {
-            SetActivityBody(activity, httpRequest.Content.ReadAsStream(), GetHttpRequestMessageEncoding(httpRequest)).Wait();
+            SetActivityBody(activity, httpRequest.Content.ReadAsStream(), GetHttpRequestMessageEncoding(httpRequest)).ConfigureAwait(false);
         }
 
         return activity;
@@ -94,7 +94,7 @@ public static class ActivityExtension
             return;
         if (length - OpenTelemetryInstrumentationOptions.MaxBodySize > 0)
         {
-            OpenTelemetryInstrumentationOptions.Logger?.LogInformation("Request body in base64 encode:{Body}", body);
+            OpenTelemetryInstrumentationOptions.Logger?.LogInformation("Request body in base64 encode: {Body}", body);
         }
         else
         {

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
@@ -29,9 +29,7 @@ public static class ActivityExtension
 
         if (httpRequest.Content is not null)
         {
-            var streamTask = httpRequest.Content.ReadAsStreamAsync();
-            streamTask.Wait();
-            SetActivityBody(activity, streamTask.Result, GetHttpRequestMessageEncoding(httpRequest)).Wait();
+            SetActivityBody(activity, httpRequest.Content.ReadAsStream(), GetHttpRequestMessageEncoding(httpRequest)).Wait();
         }
 
         return activity;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/ActivityExtensions.cs
@@ -16,7 +16,7 @@ public static class ActivityExtension
         {
             if (!httpRequest.Body.CanSeek)
                 httpRequest.EnableBuffering();
-            SetActivityBody(activity, httpRequest.Body, GetHttpRequestEncoding(httpRequest)).Wait();
+            SetActivityBody(activity, httpRequest.Body, GetHttpRequestEncoding(httpRequest)).ConfigureAwait(false);
         }
         activity.SetTag(OpenTelemetryAttributeName.Host.NAME, Dns.GetHostName());
         return activity;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/Handler/AspNetCoreInstrumentationHandler.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/Handler/AspNetCoreInstrumentationHandler.cs
@@ -5,9 +5,9 @@ namespace Masa.Contrib.StackSdks.Tsc.Tracing.Handler;
 
 public class AspNetCoreInstrumentationHandler : ExceptionHandler
 {
-    public virtual async void OnHttpRequest(Activity activity, HttpRequest httpRequest)
+    public virtual void OnHttpRequest(Activity activity, HttpRequest httpRequest)
     {
-        await activity.AddMasaSupplement(httpRequest);
+        activity.AddMasaSupplement(httpRequest);
         HttpMetricProviders.AddHttpRequestMetric(httpRequest);
     }
 

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/Handler/HttpClientInstrumentHandler.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/Handler/HttpClientInstrumentHandler.cs
@@ -5,9 +5,9 @@ namespace Masa.Contrib.StackSdks.Tsc.Tracing.Handler;
 
 public class HttpClientInstrumentHandler : ExceptionHandler
 {
-    public virtual async void OnHttpRequestMessage(Activity activity, HttpRequestMessage httpRequestMessage)
+    public virtual void OnHttpRequestMessage(Activity activity, HttpRequestMessage httpRequestMessage)
     {
-        await activity.AddMasaSupplement(httpRequestMessage);
+        _ = activity.AddMasaSupplement(httpRequestMessage);
         HttpMetricProviders.AddHttpRequestMessageMetric(httpRequestMessage);
     }
 

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/Handler/HttpClientInstrumentHandler.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/Handler/HttpClientInstrumentHandler.cs
@@ -7,7 +7,7 @@ public class HttpClientInstrumentHandler : ExceptionHandler
 {
     public virtual void OnHttpRequestMessage(Activity activity, HttpRequestMessage httpRequestMessage)
     {
-        _ = activity.AddMasaSupplement(httpRequestMessage);
+        activity.AddMasaSupplement(httpRequestMessage);
         HttpMetricProviders.AddHttpRequestMessageMetric(httpRequestMessage);
     }
 

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/MasaServiceExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/MasaServiceExtensions.cs
@@ -10,7 +10,7 @@ public static partial class MasaServiceExtensions
         services.AddOpenTelemetry().WithTracing(builder =>
         {
             builder.SetSampler(new AlwaysOnSampler());
-            var option = new OpenTelemetryInstrumentationOptions();
+            var option = new OpenTelemetryInstrumentationOptions(services.BuildServiceProvider());
             if (configure != null)
                 configure.Invoke(option);
 
@@ -30,8 +30,6 @@ public static partial class MasaServiceExtensions
                 builder.AddRedisInstrumentation(option.Connection, option.StackExchangeRedisCallsInstrumentationOptions);
 
             option.BuildTraceCallback?.Invoke(builder);
-
-            option.SetLogger(services.BuildServiceProvider().GetRequiredService<ILogger<OpenTelemetryInstrumentationOptions>>());
         }).StartWithHost();
 
         return services;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/MasaServiceExtensions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/MasaServiceExtensions.cs
@@ -30,6 +30,8 @@ public static partial class MasaServiceExtensions
                 builder.AddRedisInstrumentation(option.Connection, option.StackExchangeRedisCallsInstrumentationOptions);
 
             option.BuildTraceCallback?.Invoke(builder);
+
+            option.SetLogger(services.BuildServiceProvider().GetRequiredService<ILogger<OpenTelemetryInstrumentationOptions>>());
         }).StartWithHost();
 
         return services;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -62,7 +62,7 @@ public class OpenTelemetryInstrumentationOptions
 
     public static void SetMaxBodySize(string maxValue)
     {
-        var regex = new Regex(@"\s+");
+        var regex = new Regex(@"\s+", RegexOptions.None);
         if (maxValue is not null)
             maxValue = regex.Replace(maxValue, "");
 

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -4,7 +4,13 @@
 namespace Microsoft.Extensions.DependencyInjection;
 
 public class OpenTelemetryInstrumentationOptions
-{    
+{
+    public OpenTelemetryInstrumentationOptions(IServiceProvider serviceProvider)
+    {
+        if (Logger != null)
+            Logger = serviceProvider.GetRequiredService<ILogger<OpenTelemetryInstrumentationOptions>>();
+    }
+
     private readonly static AspNetCoreInstrumentationHandler aspNetCoreInstrumentationHandler = new();
     private readonly static HttpClientInstrumentHandler httpClientInstrumentHandler = new();
     internal static ILogger Logger { get; private set; }
@@ -54,7 +60,7 @@ public class OpenTelemetryInstrumentationOptions
     /// </summary>
     public Action<TracerProviderBuilder> BuildTraceCallback { get; set; }
 
-    public void SetMaxBodySize(string val)
+    public static void SetMaxBodySize(string val)
     {
         if (string.IsNullOrEmpty(val))
             return;
@@ -77,14 +83,9 @@ public class OpenTelemetryInstrumentationOptions
         }
     }
 
-    public void SetMaxBodySize(long val)
+    public static void SetMaxBodySize(long val)
     {
         if (val > 0)
             MaxBodySize = val;
-    }
-
-    public void SetLogger(ILogger logger)
-    {
-        Logger = logger;
     }
 }

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -62,7 +62,7 @@ public class OpenTelemetryInstrumentationOptions
 
     public static void SetMaxBodySize(string maxValue)
     {
-        var regex = new Regex(@"\s+", RegexOptions.None);
+        var regex = new Regex(@"\s+", RegexOptions.None,TimeSpan.FromSeconds(1));
         if (maxValue is not null)
             maxValue = regex.Replace(maxValue, "");
 

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -62,6 +62,9 @@ public class OpenTelemetryInstrumentationOptions
 
     public static void SetMaxBodySize(string maxValue)
     {
+        if (maxValue is not null)
+            maxValue = Regex.Replace(maxValue, @"\s+", "");
+
         if (string.IsNullOrEmpty(maxValue))
             return;
         var unit = maxValue[^1];

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -60,12 +60,12 @@ public class OpenTelemetryInstrumentationOptions
     /// </summary>
     public Action<TracerProviderBuilder> BuildTraceCallback { get; set; }
 
-    public static void SetMaxBodySize(string val)
+    public static void SetMaxBodySize(string maxValue)
     {
-        if (string.IsNullOrEmpty(val))
+        if (string.IsNullOrEmpty(maxValue))
             return;
-        var unit = val[val.Length - 1];
-        var isNum = int.TryParse(val[..(val.Length - 1)], out int num);
+        var unit = maxValue[^1];
+        var isNum = int.TryParse(maxValue[..(maxValue.Length - 1)], out int num);
         if (!isNum || num <= 0) return;
         switch (unit)
         {
@@ -83,9 +83,9 @@ public class OpenTelemetryInstrumentationOptions
         }
     }
 
-    public static void SetMaxBodySize(long val)
+    public static void SetMaxBodySize(long maxByteValue)
     {
-        if (val > 0)
-            MaxBodySize = val;
+        if (maxByteValue > 0)
+            MaxBodySize = maxByteValue;
     }
 }

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -62,8 +62,9 @@ public class OpenTelemetryInstrumentationOptions
 
     public static void SetMaxBodySize(string maxValue)
     {
+        var regex = new Regex(@"\s+");
         if (maxValue is not null)
-            maxValue = Regex.Replace(maxValue, @"\s+", "");
+            maxValue = regex.Replace(maxValue, "");
 
         if (string.IsNullOrEmpty(maxValue))
             return;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -4,9 +4,11 @@
 namespace Microsoft.Extensions.DependencyInjection;
 
 public class OpenTelemetryInstrumentationOptions
-{
+{    
     private readonly static AspNetCoreInstrumentationHandler aspNetCoreInstrumentationHandler = new();
     private readonly static HttpClientInstrumentHandler httpClientInstrumentHandler = new();
+    internal static ILogger Logger { get; private set; }
+    internal static long MaxBodySize { get; private set; } = 200 * 1 << 10;
 
     /// <summary>
     /// Default record all data. You can replace it or set null
@@ -51,4 +53,38 @@ public class OpenTelemetryInstrumentationOptions
     /// Build trace callback, allow to supplement the build process
     /// </summary>
     public Action<TracerProviderBuilder> BuildTraceCallback { get; set; }
+
+    public void SetMaxBodySize(string val)
+    {
+        if (string.IsNullOrEmpty(val))
+            return;
+        var unit = val[val.Length - 1];
+        var isNum = int.TryParse(val[..(val.Length - 1)], out int num);
+        if (!isNum || num <= 0) return;
+        switch (unit)
+        {
+            case 'k':
+            case 'K':
+                MaxBodySize = num * 1 << 10;
+                break;
+            case 'm':
+            case 'M':
+                MaxBodySize = num * 1 << 20;
+                break;
+            default:
+                MaxBodySize = num;
+                break;
+        }
+    }
+
+    public void SetMaxBodySize(long val)
+    {
+        if (val > 0)
+            MaxBodySize = val;
+    }
+
+    public void SetLogger(ILogger logger)
+    {
+        Logger = logger;
+    }
 }

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/Tracing/OpenTelemetryInstrumentationOptions.cs
@@ -62,7 +62,7 @@ public class OpenTelemetryInstrumentationOptions
 
     public static void SetMaxBodySize(string maxValue)
     {
-        var regex = new Regex(@"\s+", RegexOptions.None,TimeSpan.FromSeconds(1));
+        var regex = new Regex(@"\s+", RegexOptions.None, TimeSpan.FromSeconds(1));
         if (maxValue is not null)
             maxValue = regex.Replace(maxValue, "");
 

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/_Imports.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/_Imports.cs
@@ -35,3 +35,4 @@ global using System.Net.Http.Headers;
 global using System.Runtime.CompilerServices;
 global using System.Text;
 global using System.Text.Json;
+global using System.Text.RegularExpressions;

--- a/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/_Imports.cs
+++ b/src/Contrib/StackSdks/Masa.Contrib.StackSdks.Tsc/_Imports.cs
@@ -15,6 +15,7 @@ global using Masa.Contrib.StackSdks.Tsc.Service;
 global using Masa.Contrib.StackSdks.Tsc.Tracing.Handler;
 global using Microsoft.AspNetCore.Http;
 global using Microsoft.Extensions.Configuration;
+global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
 global using OpenTelemetry;
 global using OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient;

--- a/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Extensions/SteamTests.cs
+++ b/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Extensions/SteamTests.cs
@@ -32,7 +32,7 @@ public class SteamTests
 
         using var ms = new MemoryStream(bytes);
 
-        (long _, string? str) = await ms.ReadAsStringAsync(encoding: coding,bufferSize:16);
+        (long _, string? str) = await ms.ReadAsStringAsync(encoding: coding, bufferSize: 16);
 
         Debug.WriteLine(str);
 
@@ -45,7 +45,7 @@ public class SteamTests
     [TestMethod]
     public async Task NullStreamReadTest()
     {
-        (long _,string? text) = await default(Stream)!.ReadAsStringAsync();
+        (long _, string? text) = await default(Stream)!.ReadAsStringAsync();
         Assert.IsNull(text);
     }
 }

--- a/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Extensions/SteamTests.cs
+++ b/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Extensions/SteamTests.cs
@@ -32,7 +32,9 @@ public class SteamTests
 
         using var ms = new MemoryStream(bytes);
 
-        var str = await ms.ReadAsStringAsync(encoding: coding, bufferSize: 16);
+        (long _, string? str) = await ms.ReadAsStringAsync(encoding: coding,bufferSize:16);
+
+        Debug.WriteLine(str);
 
         if (string.IsNullOrEmpty(text))
             Assert.IsNull(str);
@@ -43,7 +45,7 @@ public class SteamTests
     [TestMethod]
     public async Task NullStreamReadTest()
     {
-        var text = await default(Stream)!.ReadAsStringAsync();
+        (long _,string? text) = await default(Stream)!.ReadAsStringAsync();
         Assert.IsNull(text);
     }
 }

--- a/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Trace/ActivityTest.cs
+++ b/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Trace/ActivityTest.cs
@@ -13,7 +13,7 @@ public class ActivityTest
     }
 
     [TestMethod]
-    public async Task HttpRequestMessageAddTagsTest()
+    public void HttpRequestMessageAddTagsTest()
     {
         HttpRequestMessage request = new();
         request.Method = HttpMethod.Post;
@@ -22,7 +22,7 @@ public class ActivityTest
         request.RequestUri = new Uri("http://localhost");
 
         var activity = new Activity("tets");
-        await activity.AddMasaSupplement(request);
+        activity.AddMasaSupplement(request);
         Assert.AreEqual(body, activity.GetTagItem(OpenTelemetryAttributeName.Http.REQUEST_CONTENT_BODY) as string);
     }
 
@@ -31,7 +31,7 @@ public class ActivityTest
     {
         HttpResponseMessage response = new()
         {
-            StatusCode = System.Net.HttpStatusCode.OK,
+            StatusCode = HttpStatusCode.OK,
             Content = new StringContent("OK")
         };
 
@@ -41,7 +41,7 @@ public class ActivityTest
     }
 
     [TestMethod]
-    public async Task HttpRequestAddTagsTest()
+    public void HttpRequestAddTagsTest()
     {
         Mock<HttpRequest> mock = new();
         mock.Setup(request => request.Method).Returns("post");
@@ -59,7 +59,7 @@ public class ActivityTest
         mock.Setup(request => request.ContentLength).Returns(ms.Length);
 
         var activity = new Activity("tets");
-        await activity.AddMasaSupplement(mock.Object);
+        activity.AddMasaSupplement(mock.Object);
         Assert.IsNotNull(activity);
         Assert.AreEqual("http", activity.GetTagItem(OpenTelemetryAttributeName.Http.SCHEME) as string);
         Assert.AreEqual("http1.1", activity.GetTagItem(OpenTelemetryAttributeName.Http.FLAVOR) as string);

--- a/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Trace/TraceTests.cs
+++ b/src/Contrib/StackSdks/Tests/Masa.Contrib.StackSdks.Tsc.Test/Trace/TraceTests.cs
@@ -24,7 +24,7 @@ public class TraceTests
                     if (uri != null)
                         options.Endpoint = uri;
                 });
-                builder.AddInMemoryExporter(logRecords);
+                builder.AddInMemoryExporter(logRecords);                
                 isConfigureCalled = true;
             });
         });


### PR DESCRIPTION
 - Read the body stream instead of synchronization.
 - if body size is less or equal 200k, tracing will record body ,else record in log with base64 encoding.