### PR TITLE
feat: Support issues-35

### DIFF
--- a/src/BuildingBlocks/Dispatcher/Masa.BuildingBlocks.Dispatcher.IntegrationEvents/Logs/IntegrationEventLog.cs
+++ b/src/BuildingBlocks/Dispatcher/Masa.BuildingBlocks.Dispatcher.IntegrationEvents/Logs/IntegrationEventLog.cs
@@ -11,15 +11,13 @@ public class IntegrationEventLog : IHasConcurrencyStamp
 
     public string EventTypeName { get; private set; } = null!;
 
-    [NotMapped]
-    public string EventTypeShortName => EventTypeName.Split('.').Last();
+    [NotMapped] public string EventTypeShortName => EventTypeName.Split('.').Last();
 
     private object? _event;
 
     [NotMapped] public object Event => _event ??= JsonSerializer.Deserialize<object>(Content)!;
 
-    [NotMapped]
-    public string Topic { get; private set; } = null!;
+    [NotMapped] public string Topic { get; private set; } = null!;
 
     public IntegrationEventStates State { get; set; } = IntegrationEventStates.NotPublished;
 
@@ -37,12 +35,16 @@ public class IntegrationEventLog : IHasConcurrencyStamp
 
     private IntegrationEventLog()
     {
-        Id = Guid.NewGuid();
         Initialize();
     }
 
-    public IntegrationEventLog(IIntegrationEvent @event, Guid transactionId) : this()
+    public IntegrationEventLog(IIntegrationEvent @event, Guid transactionId) : this(Guid.NewGuid(), @event, transactionId)
     {
+    }
+
+    public IntegrationEventLog(Guid id, IIntegrationEvent @event, Guid transactionId) : this()
+    {
+        Id = id;
         EventId = @event.GetEventId();
         CreationTime = @event.GetCreationTime();
         ModificationTime = @event.GetCreationTime();
@@ -64,8 +66,9 @@ public class IntegrationEventLog : IHasConcurrencyStamp
         Topic = json!.Topic;
         if (Topic.IsNullOrWhiteSpace())
         {
-            Topic = EventTypeShortName;//Used to handle when the Topic is not persisted, it is consistent with the class name by default
+            Topic = EventTypeShortName; //Used to handle when the Topic is not persisted, it is consistent with the class name by default
         }
+
         return this;
     }
 

--- a/src/BuildingBlocks/Dispatcher/Masa.BuildingBlocks.Dispatcher.IntegrationEvents/Options/LocalMessageTableOptions.cs
+++ b/src/BuildingBlocks/Dispatcher/Masa.BuildingBlocks.Dispatcher.IntegrationEvents/Options/LocalMessageTableOptions.cs
@@ -17,8 +17,10 @@ public class LocalMessageTableOptions
         {
             if (DbContextType == null)
                 _sectionName = string.Empty;
-            
+
             return _sectionName ??= ConnectionStringNameAttribute.GetConnStringName(DbContextType!);
         }
     }
+
+    public IIdGenerator<Guid>? IdGenerator { get; set; }
 }

--- a/src/Contrib/Dispatcher/IntegrationEvents/Masa.Contrib.Dispatcher.IntegrationEvents.EventLogs.EFCore/Extensions/IntegrationEventOptionsExtensions.cs
+++ b/src/Contrib/Dispatcher/IntegrationEvents/Masa.Contrib.Dispatcher.IntegrationEvents.EventLogs.EFCore/Extensions/IntegrationEventOptionsExtensions.cs
@@ -30,9 +30,14 @@ public static class IntegrationEventOptionsExtensions
             option.DbContextType = typeof(TDbContext);
         });
 
-        options.Services.TryAddScoped<IIntegrationEventLogService>(serviceProvider => new IntegrationEventLogService(
-            serviceProvider.GetRequiredService<IntegrationEventLogContext>(),
-            serviceProvider.GetService<ILogger<IntegrationEventLogService>>()));
+        options.Services.TryAddScoped<IIntegrationEventLogService>(serviceProvider =>
+        {
+            var idGenerator = serviceProvider.GetRequiredService<IOptions<LocalMessageTableOptions>>().Value.IdGenerator?? serviceProvider.GetService<IIdGenerator<Guid>>();
+            return new IntegrationEventLogService(
+                serviceProvider.GetRequiredService<IntegrationEventLogContext>(),
+                idGenerator,
+                serviceProvider.GetService<ILogger<IntegrationEventLogService>>());
+        });
 
         //Add local message table model mapping
         if (!disableEntityTypeConfiguration)

--- a/src/Contrib/Dispatcher/IntegrationEvents/Masa.Contrib.Dispatcher.IntegrationEvents.EventLogs.EFCore/_Imports.cs
+++ b/src/Contrib/Dispatcher/IntegrationEvents/Masa.Contrib.Dispatcher.IntegrationEvents.EventLogs.EFCore/_Imports.cs
@@ -10,6 +10,7 @@ global using Microsoft.EntityFrameworkCore.Metadata.Builders;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;
 global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Options;
 global using System;
 global using System.Collections.Generic;
 global using System.Data.Common;

--- a/src/Contrib/Dispatcher/IntegrationEvents/Tests/Masa.Contrib.Dispatcher.IntegrationEvents.EventLogs.EFCore.Tests/_Imports.cs
+++ b/src/Contrib/Dispatcher/IntegrationEvents/Tests/Masa.Contrib.Dispatcher.IntegrationEvents.EventLogs.EFCore.Tests/_Imports.cs
@@ -1,6 +1,7 @@
 // Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+global using Masa.BuildingBlocks.Data;
 global using Masa.BuildingBlocks.Data.UoW;
 global using Masa.BuildingBlocks.Dispatcher.IntegrationEvents;
 global using Masa.BuildingBlocks.Dispatcher.IntegrationEvents.Logs;


### PR DESCRIPTION
# Description

Support issues-35

Get primary key id priority:

1. specifyIdGenerator

```csharp
services.Configure<LocalMessageTableOptions>(option =>
{
    option.IdGenerator = new CustomIdGenerator();
});

public class CustomIdGenerator : IIdGenerator<Guid>
{
    public Guid NewId()
    {
        throw new NotImplementedException();
    }

    public string NewStringId()
    {
        throw new NotImplementedException();
    }
}
```

2. The local message table is not configured with an IdGenerator, but the project uses an ordered Guid constructor or an unordered Id constructor

```csharp
var services = new ServiceCollection();
services.AddSequentialGuidGenerator();// or use services.AddIdGenerator(options => options.UseSequentialGuidGenerator());
```

> add nuget `Masa.Contrib.Data.IdGenerator.SequentialGuid`

or

```csharp
var services = new ServiceCollection();
services.AddSimpleGuidGenerator();// or services.AddIdGenerator(options => options.UseSimpleGuidGenerator());
```

> add nuget `Masa.Contrib.Data.IdGenerator.NormalGuid`

3. do nothing

//Guid.NewGuid is used by default

## Issue reference

[issues-35](https://github.com/masastack/MASA.Framework/issues/35)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
