### PR TITLE
fix: Correct the MaxRetryTimes default value to 10

### DIFF
--- a/src/Contrib/Extensions/Masa.Contrib.Extensions.BackgroundJobs/BackgroundJobOptions.cs
+++ b/src/Contrib/Extensions/Masa.Contrib.Extensions.BackgroundJobs/BackgroundJobOptions.cs
@@ -38,11 +38,11 @@ public class BackgroundJobOptions
         }
     }
 
-    private int _maxRetryTimes = 30;
+    private int _maxRetryTimes = 10;
 
     /// <summary>
     /// Maximum number of retries
-    /// Default is 10
+    /// Default: 10
     /// </summary>
     public int MaxRetryTimes
     {

--- a/src/Contrib/Extensions/Tests/Masa.Contrib.Extensions.BackgroundJobs.Tests/BackgroundJobOptionsTest.cs
+++ b/src/Contrib/Extensions/Tests/Masa.Contrib.Extensions.BackgroundJobs.Tests/BackgroundJobOptionsTest.cs
@@ -11,7 +11,7 @@ public class BackgroundJobOptionsTest
     {
         var backgroundJobOptions = new BackgroundJobOptions();
         Assert.AreEqual(30, backgroundJobOptions.BatchSize);
-        Assert.AreEqual(30, backgroundJobOptions.MaxRetryTimes);
+        Assert.AreEqual(10, backgroundJobOptions.MaxRetryTimes);
         Assert.AreEqual(60, backgroundJobOptions.FirstWaitDuration);
         Assert.AreEqual(2, backgroundJobOptions.WaitDuration);
 


### PR DESCRIPTION
# Description

The default value described in the comment for the `MaxRetryTimes` is 10, but the `_maxRetryTimes` is set 30 default, I think 10 is a properly value, so I correct the `MaxRetryTimes` default value to 10
```c#
public class BackgroundJobOptions
{
  private int _maxRetryTimes = 10;
}
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
