### PR TITLE
feat: UseFilter命名空间修改，MasaApp增加TryAddAssemblies

### DIFF
--- a/src/BuildingBlocks/Data/Masa.BuildingBlocks.Data/MasaApp.cs
+++ b/src/BuildingBlocks/Data/Masa.BuildingBlocks.Data/MasaApp.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.BuildingBlocks.Data;
@@ -90,6 +90,26 @@ public static class MasaApp
     /// <param name="assemblies"></param>
     public static void SetAssemblies(IEnumerable<Assembly> assemblies)
         => Assemblies = assemblies;
+
+    public static void TryAddAssemblies(params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        if (Assemblies == null)
+            Assemblies = assemblies;
+        else
+            Assemblies = Assemblies.Concat(assemblies);
+    }
+
+    public static void TryAddAssemblies(IEnumerable<Assembly> assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        if (Assemblies == null)
+            Assemblies = assemblies.ToArray();
+        else
+            Assemblies = Assemblies.Concat(assemblies);
+    }
 
     public static IEnumerable<Assembly> GetAssemblies() => Assemblies ?? AppDomain.CurrentDomain.GetAssemblies();
 

--- a/src/Contrib/Data/Contracts/Masa.Contrib.Data.Contracts/MasaDbContextBuilderExtensions.cs
+++ b/src/Contrib/Data/Contracts/Masa.Contrib.Data.Contracts/MasaDbContextBuilderExtensions.cs
@@ -3,7 +3,7 @@
 
 // ReSharper disable once CheckNamespace
 
-namespace Microsoft.EntityFrameworkCore;
+namespace Masa.BuildingBlocks.Data;
 
 public static class MasaDbContextBuilderExtensions
 {


### PR DESCRIPTION
1. UseFilter命名空间修改，Masa.Contrib.Data.Contracts项目与EF无关。
2. MasaApp增加TryAddAssemblies方法，应对已设置并需要增加的情况。