### PR TITLE
fix:Twepoch timestamp at different accuracies

### DIFF
--- a/src/Contrib/Data/IdGenerator/Snowflake/Masa.Contrib.Data.IdGenerator.Snowflake/BaseIdGenerator.cs
+++ b/src/Contrib/Data/IdGenerator/Snowflake/Masa.Contrib.Data.IdGenerator.Snowflake/BaseIdGenerator.cs
@@ -49,7 +49,7 @@ public abstract class BaseIdGenerator : IdGeneratorBase<long>
         _workerProvider = workerProvider;
         TimestampType = snowflakeGeneratorOptions.TimestampType;
         MaxCallBackTime = snowflakeGeneratorOptions.MaxCallBackTime;
-        Twepoch = new DateTimeOffset(snowflakeGeneratorOptions.BaseTime).ToUnixTimeMilliseconds();
+        Twepoch = new DateTimeOffset(snowflakeGeneratorOptions.BaseTime).GetTimestamp(TimestampType);
         SequenceMask = ~(-1 << snowflakeGeneratorOptions.SequenceBits);
         SequenceBits = snowflakeGeneratorOptions.SequenceBits;
         TimestampLeftShift = snowflakeGeneratorOptions.SequenceBits + snowflakeGeneratorOptions.WorkerIdBits;


### PR DESCRIPTION
# Description

Twepoch 也应该根据TimestampType转换成对应精度的时间戳