### PR TITLE
fix: IgnoreInjection support ImplementationType

### DIFF
--- a/src/Utils/Extensions/Masa.Utils.Extensions.DependencyInjection/DefaultTypeProvider.cs
+++ b/src/Utils/Extensions/Masa.Utils.Extensions.DependencyInjection/DefaultTypeProvider.cs
@@ -37,7 +37,7 @@ public class DefaultTypeProvider : TypeProviderBase
     public virtual List<Type> GetImplementationTypes(List<Type> types, Type serviceType)
     {
         if (serviceType.IsInterface)
-            return types.Where(t => !t.IsAbstract && t.IsClass && IsAssignableFrom(serviceType, t)).ToList();
+            return types.Where(t => t.IsClass && IsAssignableFrom(serviceType, t) && !IsSkip(t)).ToList();
 
         return new List<Type>
         {

--- a/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/DependencyInjectionTest.cs
+++ b/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/DependencyInjectionTest.cs
@@ -27,6 +27,7 @@ public class DependencyInjectionTest
         Assert.IsTrue(_typeProvider.IsSkip(typeof(OrderService)));
         Assert.IsTrue(_typeProvider.IsSkip(typeof(UserBaseService)));
         Assert.IsFalse(_typeProvider.IsSkip(typeof(UserService)));
+        Assert.IsTrue(_typeProvider.IsSkip(typeof(IgnoreRepository)));
     }
 
     [TestMethod]
@@ -40,7 +41,7 @@ public class DependencyInjectionTest
     public void TestGetServiceTypesByScopedReturnCountIs3()
     {
         var serviceTypes = _typeProvider.GetServiceTypes(_allTypes.ToList(), typeof(IScopedDependency));
-        Assert.IsTrue(serviceTypes.Count == 3);
+        Assert.IsTrue(serviceTypes.Count == 4);
     }
 
     [TestMethod]
@@ -51,6 +52,13 @@ public class DependencyInjectionTest
 
         implementationTypes = _typeProvider.GetImplementationTypes(_allTypes.ToList(), typeof(BaseService));
         Assert.IsTrue(implementationTypes.Count == 1);
+    }
+
+    [TestMethod]
+    public void TestGetImplementationTypesSkip()
+    {
+        var implementationTypes = _typeProvider.GetImplementationTypes(_allTypes.ToList(), typeof(IRepository<Ignore>));
+        Assert.IsTrue(implementationTypes.Count == 0);
     }
 
     [TestMethod]

--- a/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/Domain/Models/Ignore.cs
+++ b/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/Domain/Models/Ignore.cs
@@ -1,0 +1,8 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Utils.Extensions.DependencyInjection.Tests.Domain.Models;
+
+public class Ignore
+{
+}

--- a/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/Domain/Repositories/IIgnoreRepository.cs
+++ b/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/Domain/Repositories/IIgnoreRepository.cs
@@ -1,0 +1,9 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Utils.Extensions.DependencyInjection.Tests.Domain.Repositories;
+
+public interface IIgnoreRepository : IRepository<Ignore>
+{
+
+}

--- a/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/Infrastructure/Repositories/IgnoreRepository.cs
+++ b/src/Utils/Extensions/Tests/Masa.Utils.Extensions.DependencyInjection.Tests/Infrastructure/Repositories/IgnoreRepository.cs
@@ -1,0 +1,9 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Utils.Extensions.DependencyInjection.Tests.Infrastructure.Repositories;
+
+[IgnoreInjection]
+public class IgnoreRepository : IIgnoreRepository
+{
+}


### PR DESCRIPTION
# Description

Look this:
```csharp
using Microsoft.Extensions.DependencyInjection;

var services = new ServiceCollection();

services.AddAutoInject();

var sp = services.BuildServiceProvider();

var userServices = sp.GetServices<IUserService>();

// We expect to output only UserService1, but it includes UserService2
Console.WriteLine(string.Join(Environment.NewLine, userServices.Select(s => s.ToString())));

public interface IUserService : ITransientDependency { }

public class UserService1 : IUserService { }

[IgnoreInjection]
public class UserService2 : IUserService { }
```

## Issue reference

None

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [✔] Code compiles correctly
* [✔] Created/updated tests
* [✔] Extended the documentation
