### PR TITLE
🐛 fix: Fix BlazorCurrentPrincipalAccessor in BlazorWebAssembly

### DIFF
--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/BlazorCurrentPrincipalAccessor.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/BlazorCurrentPrincipalAccessor.cs
@@ -5,15 +5,15 @@ namespace Masa.Contrib.Authentication.Identity.BlazorWebAssembly;
 
 public class BlazorCurrentPrincipalAccessor : ICurrentPrincipalAccessor
 {
-    readonly AuthenticationStateProvider _authenticationStateProvider;
+    protected MasaComponentsClaimsCache ClaimsCache { get; }
 
-    public BlazorCurrentPrincipalAccessor(AuthenticationStateProvider authenticationStateProvider)
+    public BlazorCurrentPrincipalAccessor(IClientScopeServiceProviderAccessor clientScopeServiceProviderAccessor)
     {
-        _authenticationStateProvider = authenticationStateProvider;
+        ClaimsCache = clientScopeServiceProviderAccessor.ServiceProvider.GetRequiredService<MasaComponentsClaimsCache>();
     }
 
     public ClaimsPrincipal? GetCurrentPrincipal()
     {
-        return _authenticationStateProvider.GetAuthenticationStateAsync().Result.User;
+        return ClaimsCache.Principal;
     }
 }

--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/ComponentsClientScopeServiceProviderAccessor.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/ComponentsClientScopeServiceProviderAccessor.cs
@@ -1,0 +1,9 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.Identity.BlazorWebAssembly;
+
+public class ComponentsClientScopeServiceProviderAccessor : IClientScopeServiceProviderAccessor
+{
+    public IServiceProvider ServiceProvider { get; set; }
+}

--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/MasaComponentsClaimsCache.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/MasaComponentsClaimsCache.cs
@@ -1,0 +1,32 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.Identity.BlazorWebAssembly;
+
+public class MasaComponentsClaimsCache : IScopedDependency
+{
+    public ClaimsPrincipal Principal { get; private set; }
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+
+    public MasaComponentsClaimsCache(
+        IClientScopeServiceProviderAccessor serviceProviderAccessor)
+    {
+        _authenticationStateProvider = serviceProviderAccessor.ServiceProvider.GetService<AuthenticationStateProvider>();
+        if (_authenticationStateProvider != null)
+        {
+            _authenticationStateProvider.AuthenticationStateChanged += async (task) =>
+            {
+                Principal = (await task).User;
+            };
+        }
+    }
+
+    public virtual async Task InitializeAsync()
+    {
+        if (_authenticationStateProvider != null)
+        {
+            var authenticationState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+            Principal = authenticationState.User;
+        }
+    }
+}

--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/ServiceCollectionExtensions.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/ServiceCollectionExtensions.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 // ReSharper disable once CheckNamespace
+
 namespace Microsoft.Extensions.DependencyInjection;
 
 public static class ServiceCollectionExtensions
@@ -31,7 +32,16 @@ public static class ServiceCollectionExtensions
     private static IServiceCollection AddMasaIdentityCore(IServiceCollection services)
     {
         services.AddAuthorizationCore();
+        services.TryAddSingleton<IClientScopeServiceProviderAccessor, ComponentsClientScopeServiceProviderAccessor>();
         services.TryAddScoped<ICurrentPrincipalAccessor, BlazorCurrentPrincipalAccessor>();
         return services;
+    }
+
+    public static async Task InitializeApplicationAsync(
+        [NotNull] this IServiceProvider serviceProvider)
+    {
+        ((ComponentsClientScopeServiceProviderAccessor)serviceProvider
+            .GetRequiredService<IClientScopeServiceProviderAccessor>()).ServiceProvider = serviceProvider;
+        await serviceProvider.GetRequiredService<IClientScopeServiceProviderAccessor>().ServiceProvider.GetRequiredService<MasaComponentsClaimsCache>().InitializeAsync();
     }
 }

--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/ServiceCollectionExtensions.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class ServiceCollectionExtensions
     private static IServiceCollection AddMasaIdentityCore(IServiceCollection services)
     {
         services.AddAuthorizationCore();
+        services.TryAddScoped<MasaComponentsClaimsCache>();
         services.TryAddSingleton<IClientScopeServiceProviderAccessor, ComponentsClientScopeServiceProviderAccessor>();
         services.TryAddScoped<ICurrentPrincipalAccessor, BlazorCurrentPrincipalAccessor>();
         return services;

--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/_Imports.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.BlazorWebAssembly/_Imports.cs
@@ -3,7 +3,10 @@
 
 global using Masa.Contrib.Authentication.Identity;
 global using Masa.Contrib.Authentication.Identity.BlazorWebAssembly;
+global using Masa.Contrib.Authentication.Identity.Core;
 global using Microsoft.AspNetCore.Components.Authorization;
+global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Security.Claims;
 global using System.Text.Json;

--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.Core/IClientScopeServiceProviderAccessor.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.Core/IClientScopeServiceProviderAccessor.cs
@@ -1,0 +1,9 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Contrib.Authentication.Identity.Core;
+
+public interface IClientScopeServiceProviderAccessor
+{
+    IServiceProvider ServiceProvider { get; }
+}

--- a/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.Core/ICurrentPrincipalAccessor.cs
+++ b/src/Contrib/Authentication/Identity/Masa.Contrib.Authentication.Identity.Core/ICurrentPrincipalAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Contrib.Authentication.Identity;

--- a/src/Contrib/Authentication/Identity/Tests/Masa.Contrib.Authentication.Identity.BlazorWebAssembly.Tests/IdentityTest.cs
+++ b/src/Contrib/Authentication/Identity/Tests/Masa.Contrib.Authentication.Identity.BlazorWebAssembly.Tests/IdentityTest.cs
@@ -21,7 +21,7 @@ public class IdentityTest
     }
 
     [TestMethod]
-    public void TestMasaIdentity2()
+    public async Task TestMasaIdentity2Async()
     {
         var services = new ServiceCollection();
         var claimsPrincipal = new ClaimsPrincipal(new List<ClaimsIdentity>()
@@ -44,6 +44,9 @@ public class IdentityTest
             option.UserId = "sub";
         });
 
+        var serviceProvider = services.BuildServiceProvider();
+        await serviceProvider.InitializeApplicationAsync();
+
         Assert.IsTrue(services.Any<ICurrentPrincipalAccessor, BlazorCurrentPrincipalAccessor>(ServiceLifetime.Scoped));
         Assert.IsTrue(services.Any<IUserSetter>(ServiceLifetime.Scoped));
         Assert.IsTrue(services.Any<IUserContext>(ServiceLifetime.Scoped));
@@ -51,7 +54,7 @@ public class IdentityTest
         Assert.IsTrue(services.Any<IMultiEnvironmentUserContext>(ServiceLifetime.Scoped));
         Assert.IsTrue(services.Any<IIsolatedUserContext>(ServiceLifetime.Scoped));
 
-        var serviceProvider = services.BuildServiceProvider();
+        
         var userContext = serviceProvider.GetService<IUserContext>();
         Assert.IsNotNull(userContext);
         Assert.AreEqual("1", userContext.UserId);
@@ -63,7 +66,7 @@ public class IdentityTest
     }
 
     [TestMethod]
-    public void TestIdentityByYaml()
+    public async Task TestIdentityByYamlAsync()
     {
         var services = new ServiceCollection();
         services.AddMasaIdentity(string.Empty);
@@ -95,6 +98,7 @@ public class IdentityTest
 
         services.AddScoped(_ => authenticationStateProvider.Object);
         serviceProvider = services.BuildServiceProvider();
+        await serviceProvider.InitializeApplicationAsync();
 
         var userContext = serviceProvider.GetService<IUserContext>();
         Assert.IsNotNull(userContext);
@@ -108,7 +112,7 @@ public class IdentityTest
     }
 
     [TestMethod]
-    public void TestIdentityByYamlAndCustomOptions()
+    public async Task TestIdentityByYamlAndCustomOptionsAsync()
     {
         var services = new ServiceCollection();
         services.AddMasaIdentity(string.Empty, option =>
@@ -143,6 +147,7 @@ public class IdentityTest
 
         services.AddScoped(_ => authenticationStateProvider.Object);
         serviceProvider = services.BuildServiceProvider();
+        await serviceProvider.InitializeApplicationAsync();
 
         var userContext = serviceProvider.GetService<IUserContext>();
         Assert.IsNotNull(userContext);

--- a/src/Contrib/Authentication/Identity/Tests/Masa.Contrib.Authentication.Identity.BlazorWebAssembly.Tests/IdentityTest.cs
+++ b/src/Contrib/Authentication/Identity/Tests/Masa.Contrib.Authentication.Identity.BlazorWebAssembly.Tests/IdentityTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 namespace Masa.Contrib.Authentication.Identity.BlazorWebAssembly.Tests;


### PR DESCRIPTION
在 WebAssembly (WASM) 的环境中，由于它是单线程的，无法直接使用同步等待