### PR TITLE
feat(AutoComplete): update UseElasticSearch method signature

### DIFF
--- a/src/Contrib/SearchEngine/AutoComplete/Masa.Contrib.SearchEngine.AutoComplete.ElasticSearch/Extensions/AutoCompleteOptionsExtensions.cs
+++ b/src/Contrib/SearchEngine/AutoComplete/Masa.Contrib.SearchEngine.AutoComplete.ElasticSearch/Extensions/AutoCompleteOptionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
+// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 // ReSharper disable once CheckNamespace
@@ -9,7 +9,7 @@ public static class AutoCompleteOptionsExtensions
 {
     public static ElasticSearchBuilder UseElasticSearch(
         this AutoCompleteOptionsBuilder autoCompleteOptionsBuilder,
-        Action<ElasticSearchAutoCompleteOptions> action)
+        Action<IServiceProvider, ElasticSearchAutoCompleteOptions> action)
     {
         MasaArgumentException.ThrowIfNull(action);
 
@@ -17,7 +17,7 @@ public static class AutoCompleteOptionsExtensions
         autoCompleteOptionsBuilder.UseCustomAutoComplete(serviceProvider =>
         {
             var elasticSearchAutoCompleteOptions = new ElasticSearchAutoCompleteOptions();
-            action.Invoke(elasticSearchAutoCompleteOptions);
+            action.Invoke(serviceProvider, elasticSearchAutoCompleteOptions);
             MasaArgumentException.ThrowIfNullOrWhiteSpace(elasticSearchAutoCompleteOptions.IndexName);
 
             var elasticClientProvider = serviceProvider.GetRequiredService<IElasticClientProvider>();

--- a/src/Contrib/SearchEngine/AutoComplete/Tests/Masa.Contrib.SearchEngine.AutoComplete.ElasticSearch.Tests/AutoCompleteTest.cs
+++ b/src/Contrib/SearchEngine/AutoComplete/Tests/Masa.Contrib.SearchEngine.AutoComplete.ElasticSearch.Tests/AutoCompleteTest.cs
@@ -22,7 +22,7 @@ public class AutoCompleteTest
         string indexName = $"index_{Guid.NewGuid()}";
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting =>
@@ -50,7 +50,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -103,7 +103,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -134,7 +134,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -166,7 +166,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -211,7 +211,7 @@ public class AutoCompleteTest
 
         _services.AddAutoCompleteBySpecifyDocument<Employee>("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -257,7 +257,7 @@ public class AutoCompleteTest
         string analyzer = "ik_max_word_pinyin";
         _services.AddAutoCompleteBySpecifyDocument<Employee>("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -366,7 +366,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -415,7 +415,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -454,7 +454,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -493,7 +493,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -531,7 +531,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -572,7 +572,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -619,7 +619,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -671,7 +671,7 @@ public class AutoCompleteTest
     {
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));
@@ -721,7 +721,7 @@ public class AutoCompleteTest
         var indexName = $"index_{Guid.NewGuid()}";
         _services.AddAutoComplete("es", autoCompleteOptions =>
         {
-            autoCompleteOptions.UseElasticSearch(options =>
+            autoCompleteOptions.UseElasticSearch((serviceProvider, options) =>
             {
                 options.ElasticsearchOptions.UseNodes(_defaultNode);
                 options.ElasticsearchOptions.UseConnectionSettings(setting => setting.EnableApiVersioningHeader(false));


### PR DESCRIPTION
Changed the parameter type of the `UseElasticSearch` method in `AutoCompleteOptionsExtensions.cs` from `Action<ElasticSearchAutoCompleteOptions>` to `Action<IServiceProvider, ElasticSearchAutoCompleteOptions>`. Updated internal method calls accordingly to pass the `IServiceProvider` instance.

Modified all calls to `UseElasticSearch` in `AutoCompleteTest.cs` to accommodate the new method signature, ensuring proper passing of `IServiceProvider` and `ElasticSearchAutoCompleteOptions` instances.

These changes enhance the flexibility of the `UseElasticSearch` method, allowing access to the service provider for configuring `ElasticSearchAutoCompleteOptions` with additional services and dependencies.