### PR TITLE
refactor(SyncCache): simplify ResetAsync method

### DIFF
--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore/Caches/SyncCache.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore/Caches/SyncCache.cs
@@ -93,7 +93,7 @@ public class SyncCache
     {
         if (_clientCache is not null)
         {
-            var clients = await ClientQueryAsync();
+            var clients = await ClientQuery().ToListAsync();
             await _clientCache.ResetAsync(clients);
         }
         if (_apiScopeCache is not null)
@@ -111,36 +111,6 @@ public class SyncCache
             var identityResource = await IdentityResourceQuery().ToListAsync();
             await _identityResourceCache.ResetAsync(identityResource);
         }
-    }
-
-    [ExcludeFromCodeCoverage]
-    public async Task<IEnumerable<Client>> ClientQueryAsync()
-    {
-        var clients = await _context.Set<Client>().ToListAsync();
-        var clientPropertys = await _context.Set<ClientProperty>().ToListAsync();
-        var clientClaims = await _context.Set<ClientClaim>().ToListAsync();
-        var clientIdPRestrictions = await _context.Set<ClientIdPRestriction>().ToListAsync();
-        var clientCorsOrigins = await _context.Set<ClientCorsOrigin>().ToListAsync();
-        var clientSecrets = await _context.Set<ClientSecret>().ToListAsync();
-        var clientGrantTypes = await _context.Set<ClientGrantType>().ToListAsync();
-        var clientRedirectUris = await _context.Set<ClientRedirectUri>().ToListAsync();
-        var clientPostLogoutRedirectUris = await _context.Set<ClientPostLogoutRedirectUri>().ToListAsync();
-        var clientScopes = await _context.Set<ClientScope>().ToListAsync();
-
-        foreach (var client in clients)
-        {
-            client.AllowedGrantTypes.AddRange(clientGrantTypes.Where(item => item.ClientId == client.Id));
-            client.RedirectUris.AddRange(clientRedirectUris.Where(item => item.ClientId == client.Id));
-            client.PostLogoutRedirectUris.AddRange(clientPostLogoutRedirectUris.Where(item => item.ClientId == client.Id));
-            client.Properties.AddRange(clientPropertys.Where(item => item.ClientId == client.Id));
-            client.Claims.AddRange(clientClaims.Where(item => item.ClientId == client.Id));
-            client.IdentityProviderRestrictions.AddRange(clientIdPRestrictions.Where(item => item.ClientId == client.Id));
-            client.AllowedCorsOrigins.AddRange(clientCorsOrigins.Where(item => item.ClientId == client.Id));
-            client.ClientSecrets.AddRange(clientSecrets.Where(item => item.ClientId == client.Id));
-            client.AllowedScopes.AddRange(clientScopes.Where(item => item.ClientId == client.Id));
-        }
-
-        return clients;
     }
 
     private IQueryable<IdentityResource> IdentityResourceQuery()


### PR DESCRIPTION
Replaced the `ClientQueryAsync` method with `ClientQuery().ToListAsync()` in the `ResetAsync` implementation. The `ClientQueryAsync` method and its internal logic have been removed, streamlining the asynchronous query process and improving code readability and maintainability.