### PR TITLE
feat:update ldap package

### DIFF
--- a/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore/Caches/SyncCache.cs
+++ b/src/Contrib/Authentication/OpenIdConnect/Masa.Contrib.Authentication.OpenIdConnect.EFCore/Caches/SyncCache.cs
@@ -93,7 +93,7 @@ public class SyncCache
     {
         if (_clientCache is not null)
         {
-            var clients = await ClientQueryAsync();
+            var clients = await ClientQuery().ToListAsync();
             await _clientCache.ResetAsync(clients);
         }
         if (_apiScopeCache is not null)
@@ -111,36 +111,6 @@ public class SyncCache
             var identityResource = await IdentityResourceQuery().ToListAsync();
             await _identityResourceCache.ResetAsync(identityResource);
         }
-    }
-
-    [ExcludeFromCodeCoverage]
-    public async Task<IEnumerable<Client>> ClientQueryAsync()
-    {
-        var clients = await _context.Set<Client>().ToListAsync();
-        var clientPropertys = await _context.Set<ClientProperty>().ToListAsync();
-        var clientClaims = await _context.Set<ClientClaim>().ToListAsync();
-        var clientIdPRestrictions = await _context.Set<ClientIdPRestriction>().ToListAsync();
-        var clientCorsOrigins = await _context.Set<ClientCorsOrigin>().ToListAsync();
-        var clientSecrets = await _context.Set<ClientSecret>().ToListAsync();
-        var clientGrantTypes = await _context.Set<ClientGrantType>().ToListAsync();
-        var clientRedirectUris = await _context.Set<ClientRedirectUri>().ToListAsync();
-        var clientPostLogoutRedirectUris = await _context.Set<ClientPostLogoutRedirectUri>().ToListAsync();
-        var clientScopes = await _context.Set<ClientScope>().ToListAsync();
-
-        foreach (var client in clients)
-        {
-            client.AllowedGrantTypes.AddRange(clientGrantTypes.Where(item => item.ClientId == client.Id));
-            client.RedirectUris.AddRange(clientRedirectUris.Where(item => item.ClientId == client.Id));
-            client.PostLogoutRedirectUris.AddRange(clientPostLogoutRedirectUris.Where(item => item.ClientId == client.Id));
-            client.Properties.AddRange(clientPropertys.Where(item => item.ClientId == client.Id));
-            client.Claims.AddRange(clientClaims.Where(item => item.ClientId == client.Id));
-            client.IdentityProviderRestrictions.AddRange(clientIdPRestrictions.Where(item => item.ClientId == client.Id));
-            client.AllowedCorsOrigins.AddRange(clientCorsOrigins.Where(item => item.ClientId == client.Id));
-            client.ClientSecrets.AddRange(clientSecrets.Where(item => item.ClientId == client.Id));
-            client.AllowedScopes.AddRange(clientScopes.Where(item => item.ClientId == client.Id));
-        }
-
-        return clients;
     }
 
     private IQueryable<IdentityResource> IdentityResourceQuery()

--- a/src/Utils/Ldap/Masa.Utils.Ldap.Novell/Entries/LdapUser.cs
+++ b/src/Utils/Ldap/Masa.Utils.Ldap.Novell/Entries/LdapUser.cs
@@ -56,4 +56,6 @@ public class LdapUser
     public string Department { get; set; } = string.Empty;
 
     public LdapAddress Address { get; set; } = new();
+
+    public UserAccountControl UserAccountControl { get; set; }
 }

--- a/src/Utils/Ldap/Masa.Utils.Ldap.Novell/Entries/UserAccountControl.cs
+++ b/src/Utils/Ldap/Masa.Utils.Ldap.Novell/Entries/UserAccountControl.cs
@@ -1,0 +1,30 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Utils.Ldap.Novell.Entries;
+
+public enum UserAccountControl
+{
+    Script = 1,
+    AccountDisabled = 2,
+    HomeDirectoryRequired = 8,
+    AccountLockedOut_DEPRECATED = 16,
+    PasswordNotRequired = 32,
+    PasswordCannotChange_DEPRECATED = 64,
+    EncryptedTextPasswordAllowed = 128,
+    TempDuplicateAccount = 256,
+    NormalAccount = 512,
+    InterDomainTrustAccount = 2048,
+    WorkstationTrustAccount = 4096,
+    ServerTrustAccount = 8192,
+    PasswordDoesNotExpire = 65536,
+    MnsLogonAccount = 131072,
+    SmartCardRequired = 262144,
+    TrustedForDelegation = 524288,
+    AccountNotDelegated = 1048576,
+    UseDesKeyOnly = 2097152,
+    DontRequirePreauth = 4194304,
+    PasswordExpired_DEPRECATED = 8388608,
+    TrustedToAuthenticateForDelegation = 16777216,
+    PartialSecretsAccount = 67108864
+}

--- a/src/Utils/Ldap/Masa.Utils.Ldap.Novell/LdapProvider.cs
+++ b/src/Utils/Ldap/Masa.Utils.Ldap.Novell/LdapProvider.cs
@@ -12,7 +12,7 @@ public class LdapProvider : ILdapProvider, IDisposable
     {
         "objectSid", "objectGUID", "objectCategory", "objectClass", "memberOf", "name", "cn", "distinguishedName",
         "sAMAccountName", "userPrincipalName", "displayName", "givenName", "sn", "description",
-        "telephoneNumber", "mail", "streetAddress", "postalCode", "l", "st", "co", "c"
+        "telephoneNumber", "mail", "streetAddress", "postalCode", "l", "st", "co", "c","userAccountControl"
     };
 
     internal LdapProvider(LdapOptions options)
@@ -219,6 +219,15 @@ public class LdapProvider : ILdapProvider, IDisposable
         ldapUser.Company = attributeSet.GetString("company");
         ldapUser.Department = attributeSet.GetString("department");
         ldapUser.Title = attributeSet.GetString("title");
+
+        if (attributeSet.TryGetValue("userAccountControl", out var userAccountControlAttribute))
+        {
+            if (int.TryParse(userAccountControlAttribute.StringValue, out var userAccountControlValue))
+            {
+                ldapUser.UserAccountControl = (UserAccountControl)userAccountControlValue;
+            }
+        }
+
         ldapUser.Address = new LdapAddress
         {
             Street = attributeSet.GetString("streetAddress"),

--- a/src/Utils/Ldap/Masa.Utils.Ldap.Novell/Masa.Utils.Ldap.Novell.csproj
+++ b/src/Utils/Ldap/Masa.Utils.Ldap.Novell/Masa.Utils.Ldap.Novell.csproj
@@ -7,7 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftPackageVersion)" />
-    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0-beta4" />
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Added `UserAccountControl` property in `LdapUser.cs` for managing user account control information.
- Introduced `UserAccountControl` enum in `UserAccountControl.cs` to define various account control flags.
- Updated `_attributes` array in `LdapProvider.cs` to include `userAccountControl` for LDAP queries.
- Implemented parsing logic for `userAccountControl` in `LdapProvider.cs` to convert its value to the `UserAccountControl` enum.
- Updated `Novell.Directory.Ldap.NETStandard` version in `Masa.Utils.Ldap.Novell.csproj` from `4.0.0-beta4` to `4.0.0` and added `System.Linq.Async` reference.